### PR TITLE
feat(fish): claude abbr で --allow-dangerously-skip-permissions を自動付与

### DIFF
--- a/nix/fish.nix
+++ b/nix/fish.nix
@@ -47,7 +47,7 @@
       # nix
       rebuild = "darwin-rebuild switch --flake ~/repos/dotfiles#macos";
       # claude
-      ccp = "claude --allow-dangerously-skip-permissions";
+      claude = "claude --allow-dangerously-skip-permissions";
     };
     functions = {
       fish_prompt = ''


### PR DESCRIPTION
## Summary
- fish の `shellAbbrs` で `ccp = "claude --allow-dangerously-skip-permissions"` を `claude = "claude --allow-dangerously-skip-permissions"` に変更
- `claude` と入力するだけで自動的に `--allow-dangerously-skip-permissions` フラグが付与されるようになる
- 不要になった `ccp` abbr を削除

## Test plan
- [ ] `darwin-rebuild switch --flake .#macos` で適用
- [ ] fish shell で `claude` と入力し、`claude --allow-dangerously-skip-permissions` に展開されることを確認
- [ ] `ccp` が未定義になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)