### PR TITLE
feat(claude): gh api レスポンスに --jq フィルタリングを導入

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -28,6 +28,15 @@
 ### Git コマンド
 - ブランチの作成は `git switch` コマンドを使用してください．
 
+### GitHub API
+- `gh api` でデータを取得する際は、必ず `--jq` フラグで必要なフィールドのみ抽出すること（トークン節約のため）。
+- `diff_hunk` のような長大なフィールドは末尾数行のみ切り出すこと。
+- 例：PR レビューコメント取得時:
+  ```bash
+  gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
+    --jq '.[] | {id, body, user: .user.login, path, line: (.line // .original_line), diff_hunk: ((.diff_hunk // "") | split("\n") | .[-5:] | join("\n")), in_reply_to_id, created_at}'
+  ```
+
 ## プルリクエスト
 - `./.github/PULL_REQUEST_TEMPLATE.md` が存在する場合，それを元にPRを作成してください．
 

--- a/config/claude/skills/pr-review-responder/SKILL.md
+++ b/config/claude/skills/pr-review-responder/SKILL.md
@@ -13,7 +13,8 @@ GitHub PRのレビューコメントを分析し、対応が必要かどうか�
 
 ```bash
 # PR番号指定の場合
-gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --paginate \
+  --jq '.[] | {id, body, user: .user.login, path, line: (.line // .original_line), diff_hunk: ((.diff_hunk // "") | split("\n") | .[-5:] | join("\n")), in_reply_to_id, created_at}'
 
 # 現在のブランチから自動検出
 gh pr view --json number -q '.number'


### PR DESCRIPTION
## Summary
- `gh api` でデータ取得時に `--jq` フラグで必要なフィールドのみ抽出するルールを `CLAUDE.md` に追加
- `pr-review-responder` スキルのコメント取得コマンドに `--paginate` と `--jq` フィルタを追加
- コメント1件あたり約80-90%のトークン削減が見込まれる（2,000-3,000文字 → 200-500文字）

## 変更内容
- `config/claude/CLAUDE.md`: 「GitHub API」セクションを追加（`--jq` 使用ルール + 例）
- `config/claude/skills/pr-review-responder/SKILL.md`: レビューコメント取得コマンドを更新

## jq フィルタで抽出するフィールド
| フィールド | 理由 |
|---|---|
| `id` | リプライ時の `in_reply_to` に必要 |
| `body` | コメント本文 |
| `user` | コメント者（`.user.login` を平坦化） |
| `path` | 対象ファイル |
| `line` | 行番号（`original_line` フォールバック付き） |
| `diff_hunk` | 末尾5行のみ抽出 |
| `in_reply_to_id` | スレッド構造の把握 |
| `created_at` | 時系列順の把握 |

## Test plan
- [ ] 任意のリポジトリの PR に対して `--jq` 付きコマンドを実行し、出力を確認
- [ ] `pr-review-responder` スキルを実際の PR で実行し、コメント分析が正常に動作することを確認
- [ ] リプライ投稿・Resolve が既存通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)