### PR TITLE
feat(nix): AWS CLI v2 を追加

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -61,6 +61,7 @@
     moreutils  # sponge コマンド（設定ファイルの in-place 更新用）
 
     # AWS
+    awscli2
     ssm-session-manager-plugin
 
     # Infrastructure


### PR DESCRIPTION
## Summary
- `nix/home.nix` の `# AWS` セクションに `awscli2` パッケージを追加
- 既存の `ssm-session-manager-plugin` と合わせて AWS ツールチェインを整備

## Test plan
- [ ] `sudo darwin-rebuild switch --flake .#macos` でビルドが成功すること
- [ ] `aws --version` で AWS CLI v2 が利用可能であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)