### PR TITLE
feat(nix): Go 1.26.0 にアップグレード

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1770812194,
+        "narHash": "sha256-OH+lkaIKAvPXR3nITO7iYZwew2nW9Y7Xxq0yfM/UcUU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "8482c7ded03bae7550f3d69884f1e611e3bd19e8",
         "type": "github"
       },
       "original": {

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -44,7 +44,7 @@
     nodePackages.pnpm
     bun
     uv
-    go
+    go_1_26
     rustup
 
     # Git tools


### PR DESCRIPTION
## Summary
- nixpkgs-unstable を 2026-01-02 → 2026-02-11 に更新
- `nix/home.nix` で `go` → `go_1_26` に変更し、バージョンを明示的にピン
- `darwin-rebuild switch` 適用済み、`go version` で `go1.26.0 darwin/arm64` を確認

## Test plan
- [x] `darwin-rebuild build` がエラーなく完了
- [x] `darwin-rebuild switch` が成功
- [x] `command -v go` が Nix store パスを指していることを確認
- [x] `go version` が `go1.26.0` を返すことを確認
- [x] `gwq --version` が正常動作（buildGoModule 互換性確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)