### PR TITLE
feat(nix): just コマンドランナーを追加

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -36,6 +36,7 @@
     fzf
     ghq
     jq
+    just
     tree
     tmux
 


### PR DESCRIPTION
## Summary
- `nix/home.nix` の CLI tools セクションに `just` パッケージを追加

## Test plan
- [ ] `sudo darwin-rebuild build --flake .#macos` でビルド確認
- [ ] `sudo darwin-rebuild switch --flake .#macos` で適用
- [ ] `just --version` でインストール確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)