### PR TITLE
feat(nix): Homebrew formulae を Nix パッケージに移行

### DIFF
--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -13,7 +13,7 @@
     enable = true;
     onActivation = {
       autoUpdate = true;
-      cleanup = "none";  # Keep existing packages not in this list
+      cleanup = "zap";  # Remove undeclared packages and their associated files
     };
     caskArgs.appdir = "/Applications";
     casks = [

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -68,6 +68,16 @@
     # Infrastructure
     terraform
 
+    # Linters
+    actionlint
+    shellcheck
+
+    # Build tools
+    ninja
+
+    # PDF tools
+    pkgs."poppler-utils"  # pdftotext, pdftoppm 等
+
     # Tools
     tailscale
     valkey


### PR DESCRIPTION
## Summary

- `actionlint`, `shellcheck`, `ninja`, `poppler-utils` を Homebrew formulae から Nix パッケージに移行
- Homebrew の `cleanup` ポリシーを `none` → `zap` に変更し、未宣言パッケージの自動削除を有効化
- これにより Homebrew は cask と masApps のみを管理する構成に

## 変更ファイル

- `nix/home.nix` — 4パッケージを `home.packages` に追加
- `nix/darwin.nix` — `homebrew.onActivation.cleanup` を `"zap"` に変更

## Test plan

- [ ] `sudo darwin-rebuild switch --flake .#macos` が成功すること
- [ ] `command -v actionlint shellcheck ninja pdftotext` で全コマンドが見つかること
- [ ] `brew list --formula | rg '^(actionlint|shellcheck|ninja|poppler)$'` が空であること
- [ ] `brew list --cask` で 13 個の cask が維持されていること
- [ ] `test -d /Applications/LINE.app` で masApps が影響を受けていないこと

## ⚠️ 注意事項

- `cleanup = "zap"` により、今後 `brew install` で手動インストールしたパッケージは次の `darwin-rebuild switch` で自動削除されます
- 一時的に使いたいパッケージは `nix-shell -p` を使うか、`darwin.nix` の `brews` に追加してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)