### PR TITLE
feat(wezterm): LEADER キー設定と直前コマンド&出力コピー機能を追加

### DIFF
--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -62,6 +62,7 @@ wezterm.on("gui-startup", function(cmd)
   window:gui_window():maximize()
 end)
 
+config.leader = { key = "b", mods = "CTRL", timeout_milliseconds = 1000 }
 config.keys = require("keybinds").keys
 config.key_tables = require("keybinds").key_tables
 config.disable_default_key_bindings = true


### PR DESCRIPTION
## Summary

- `Ctrl+b` を LEADER キーに設定（タイムアウト 1000ms）
- `LEADER+z` で直前のコマンドとその出力を Semantic Zones（OSC 133）を利用してクリップボードにコピーする機能を追加
- コピー完了時に右ステータスバーに「📋 Copied!」を 3 秒間表示（ウィンドウごとに独立した通知ステート管理）

## Test plan

- [ ] WezTerm を開き、何かコマンドを実行（例: `echo hello`）
- [ ] `Ctrl+b` → `z` を押す
- [ ] クリップボードにコマンドと出力がコピーされていることを確認（`Cmd+v` でペースト）
- [ ] 右ステータスに「📋 Copied!」が 3 秒間表示されることを確認
- [ ] 複数ウィンドウで通知が干渉しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)