### PR TITLE
feat(nix): マルチPC対応 — ホストプロファイルで環境差分を柔軟に管理

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,9 @@ macOS (Apple Silicon) 用のdotfilesリポジトリ。nix-darwinとhome-manager�
 ## よく使うコマンド
 
 ```bash
-# システム設定を適用（nix-darwin + home-manager）
-sudo darwin-rebuild switch --flake .#macos
+# システム設定を適用
+sudo darwin-rebuild switch --flake .#personal   # 個人PC
+sudo darwin-rebuild switch --flake .#work       # 仕事用PC
 
 # 設定ファイルを ~/.config からリポジトリに同期
 ./sync.sh

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,5 +1,12 @@
-{ pkgs, username, hostname, ... }:
+{ pkgs, lib, profile, ... }:
+let
+  inherit (profile) username hostname passwordManager;
 
+  passwordManagerCask = {
+    "1password" = "1password";
+    "bitwarden" = "bitwarden";
+  }.${passwordManager};
+in
 {
   # Nix settings (Determinate Nix manages the daemon)
   nix.enable = false;
@@ -17,23 +24,15 @@
     };
     caskArgs.appdir = "/Applications";
     casks = [
-      "1password"
+      passwordManagerCask
       "adobe-acrobat-reader"
-      "datagrip"
-      "discord"
       "doll"
       "google-drive"
       "orbstack"
-      "postman-agent"
       "raycast"
-      "slack"
-      "steam"
       "wezterm@nightly"
-      "zoom"
-    ];
-    masApps = {
-      LINE = 539883307;
-    };
+    ] ++ profile.extraCasks;
+    masApps = {} // profile.extraMasApps;
   };
 
   # Primary user (required for system.defaults options)

--- a/nix/fish.nix
+++ b/nix/fish.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, profile, ... }:
 
 {
   # Fish functions from external files
@@ -45,7 +45,7 @@
       kube = "kubectl";
       k8s = "kubectl";
       # nix
-      rebuild = "darwin-rebuild switch --flake ~/repos/dotfiles#macos";
+      rebuild = "darwin-rebuild switch --flake ~/repos/dotfiles#${profile.profileName}";
       # claude
       claude = "claude --allow-dangerously-skip-permissions";
     };

--- a/nix/git.nix
+++ b/nix/git.nix
@@ -1,11 +1,16 @@
-_: {
+{ lib, profile, ... }:
+let
+  useSigning = profile.git.signingKey != null;
+in
+{
   programs.git = {
     enable = true;
     lfs.enable = true;
+    userEmail = lib.mkIf (profile.git.email != null) profile.git.email;
     settings = {
       color.ui = "auto";
       commit = {
-        gpgsign = true;
+        gpgsign = useSigning;
         verbose = true;
       };
       core = {
@@ -28,6 +33,7 @@ _: {
       rerere.enabled = true;
       gpg = {
         format = "ssh";
+      } // lib.optionalAttrs (profile.passwordManager == "1password") {
         ssh.program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
       };
       url = {
@@ -35,7 +41,9 @@ _: {
           insteadOf = "https://github.com/";
         };
       };
-      user.signingkey = "~/.ssh/github.pub";
+      user = lib.optionalAttrs useSigning {
+        signingkey = profile.git.signingKey;
+      };
       ghq.root = "~/repos";
     };
     ignores = [

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, llmPkgs, weztermPkg, gwqPkg, ... }:
+{ config, pkgs, lib, llmPkgs, gwqPkg, profile, ... }:
 
 {
   imports = [
@@ -21,6 +21,8 @@
     GEMINI_CLI_HOME = "$HOME/.config";  # ~/.config/.gemini/ に設定保存
     # pnpm
     PNPM_HOME = "$HOME/.local/share/pnpm";
+  } // lib.optionalAttrs (profile.passwordManager == "bitwarden") {
+    SSH_AUTH_SOCK = "$HOME/.bitwarden-ssh-agent.sock";
   };
 
   # Let Home Manager manage itself
@@ -61,13 +63,6 @@
     llmPkgs.copilot-cli
     moreutils  # sponge コマンド（設定ファイルの in-place 更新用）
 
-    # AWS
-    awscli2
-    ssm-session-manager-plugin
-
-    # Infrastructure
-    terraform
-
     # Linters
     actionlint
     shellcheck
@@ -90,7 +85,7 @@
     nerd-fonts.hack
     nerd-fonts.intone-mono
     noto-fonts-cjk-sans
-  ];
+  ] ++ profile.extraPackages;
 
   # gwq config
   xdg.configFile."gwq/config.toml".text = ''

--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -1,0 +1,24 @@
+{ pkgs, ... }:
+{
+  hostname = "Kurichi-MacBook-Pro";
+  username = "kurichi";
+  passwordManager = "1password";
+  git = {
+    email = null;
+    signingKey = "~/.ssh/github.pub";
+  };
+  extraCasks = [
+    "datagrip"
+    "discord"
+    "postman-agent"
+    "slack"
+    "steam"
+    "zoom"
+  ];
+  extraMasApps = { LINE = 539883307; };
+  extraPackages = with pkgs; [
+    awscli2
+    ssm-session-manager-plugin
+    terraform
+  ];
+}

--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+{
+  hostname = "Work-Mac";
+  username = "kurichi";
+  passwordManager = "bitwarden";
+  git = {
+    email = null;
+    signingKey = "~/.ssh/github.pub";
+  };
+  extraCasks = [
+    "datagrip"
+    "postman-agent"
+    "slack"
+    "zoom"
+  ];
+  extraPackages = with pkgs; [
+    awscli2
+    ssm-session-manager-plugin
+    terraform
+  ];
+}


### PR DESCRIPTION
## Summary

- `nix/hosts/<name>.nix` にマシンごとの差分設定を分離するホストファイルパターンを導入
- `flake.nix` に `mkProfile` / `mkDarwinSystem` ヘルパーを追加し、`darwinConfigurations.personal` と `.work` を定義
- パスワードマネージャ（1Password / Bitwarden）に応じた cask・Git署名・SSH Agent の自動切替
- 環境固有パッケージ（AWS CLI, Terraform 等）を `extraPackages` に移動し、共通パッケージと分離
- 新マシン追加は `nix/hosts/<name>.nix` 作成 + `flake.nix` に1行追加で完了

## Test plan

- [x] `nix eval .#darwinConfigurations.personal.system` が正常に評価される
- [x] `nix eval .#darwinConfigurations.work.system` が正常に評価される
- [ ] `sudo darwin-rebuild switch --flake .#personal` で実際にビルド・適用が通る
- [ ] `brew list --cask` で期待する cask が入っている
- [ ] `git config gpg.ssh.program` が正しいパスを返す
- [ ] `type rebuild` で abbreviation が正しいフレークターゲットを指している

🤖 Generated with [Claude Code](https://claude.com/claude-code)