### PR TITLE
feat(nix): Claude Code を ryoppippi/claude-code-overlay に移行

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,16 +9,36 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1769353768,
-        "narHash": "sha256-zI+7cbMI4wMIR57jMjDSEsVb3grapTnURDxxJPYFIW0=",
+        "lastModified": 1771437256,
+        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "c7da5c70ad1c9b60b6f5d4f674fbe205d48d8f6c",
+        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "claude-code-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772003987,
+        "narHash": "sha256-6EIkULpbsKgCZCf1dRftrIY8+StocP50x2AfvDSe51U=",
+        "owner": "ryoppippi",
+        "repo": "claude-code-overlay",
+        "rev": "b10b550d3d78cb7e0789d4a4b4d599d96016db92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryoppippi",
+        "repo": "claude-code-overlay",
         "type": "github"
       }
     },
@@ -51,11 +71,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1771361172,
-        "narHash": "sha256-T2nVTHdNDIRx76CvLz+KNGw5BFJAWaci6blTgt/z0z8=",
+        "lastModified": 1772029732,
+        "narHash": "sha256-5kOeqGvyAMiwVhPtN/h09uVMmYLw7faFWjR1CcuVCM0=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "d6f44851a38e5f2d0df869c9ef13bd6bcfadcfc9",
+        "rev": "ee63fee5984b895eaf14a6fb3ca56b773d0dcc3d",
         "type": "github"
       },
       "original": {
@@ -102,6 +122,7 @@
     },
     "root": {
       "inputs": {
+        "claude-code-overlay": "claude-code-overlay",
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "Kurichi's dotfiles managed by nix-darwin and home-manager";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://ryoppippi.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
@@ -18,9 +27,14 @@
       url = "github:numtide/llm-agents.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    claude-code-overlay = {
+      url = "github:ryoppippi/claude-code-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = inputs@{ self, nixpkgs, nix-darwin, home-manager, llm-agents }:
+  outputs = inputs@{ self, nixpkgs, nix-darwin, home-manager, llm-agents, claude-code-overlay }:
     let
       username = "kurichi";
       hostname = "Kurichi-MacBook-Pro";
@@ -34,6 +48,7 @@
         inherit system;
         modules = [
           ./nix/darwin.nix
+          { nixpkgs.overlays = [ claude-code-overlay.overlays.default ]; }
           home-manager.darwinModules.home-manager
           {
             home-manager.useGlobalPkgs = true;

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -55,7 +55,7 @@
     # pkgs."git-wt"  # TODO: nixpkgs更新後に戻す
 
     # AI tools
-    llmPkgs.claude-code
+    pkgs.claude-code
     llmPkgs.codex
     llmPkgs.gemini-cli
     llmPkgs.copilot-cli


### PR DESCRIPTION
## Summary

- Claude Code のパッケージソースを `numtide/llm-agents.nix` から `ryoppippi/claude-code-overlay` に移行
- Anthropic GCS からプリビルドバイナリを直接取得し、GitHub Actions で最新版を自動追跡する仕組みを利用
- 他の LLM ツール (codex, gemini-cli, copilot-cli) は `llm-agents.nix` に残置

## Changes

### `flake.nix`
- `nixConfig` に ryoppippi の Cachix バイナリキャッシュ設定を追加
- `claude-code-overlay` を flake input に追加（`inputs.nixpkgs.follows = "nixpkgs"`）
- `darwinSystem.modules` に overlay 適用モジュールを追加

### `nix/home.nix`
- `llmPkgs.claude-code` → `pkgs.claude-code` に変更（overlay 経由で利用可能）

### `flake.lock`
- `claude-code-overlay` のロックエントリ追加

## Test plan

- [ ] `sudo darwin-rebuild switch --flake .#macos` が正常完了すること
- [ ] `which claude` が Nix ストアの ryoppippi/claude-code-overlay 由来のパスを返すこと
- [ ] `claude --version` が正常にバージョンを表示すること
- [ ] `cat $(which claude)` でラッパースクリプトに `DISABLE_AUTOUPDATER=1` 等が含まれていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)