### PR TITLE
fix(nix): claude-code の overrideAttrs リグレッションを修正

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -29,7 +29,16 @@
     # pkgs."git-wt"  # TODO: nixpkgs更新後に戻す
 
     # AI tools
-    pkgs.claude-code
+    (pkgs.claude-code.overrideAttrs (old: {
+      postFixup = builtins.replaceStrings
+        [
+          "--set DISABLE_TELEMETRY 1"
+          "--set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1"
+          "--set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1"
+        ]
+        [ "" "" "" ]
+        old.postFixup;
+    }))
     llmPkgs.codex
     llmPkgs.gemini-cli
     llmPkgs.copilot-cli


### PR DESCRIPTION
## Summary
- PR #19 のモジュール構造リファクタリング時に消失した `overrideAttrs` ブロックを `nix/modules/home/packages.nix` に復元
- `DISABLE_TELEMETRY`, `DISABLE_NON_ESSENTIAL_MODEL_CALLS`, `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` の環境変数がラッパースクリプトから除去されるように修正
- `nix run .#build` でビルド成功を確認済み

## Background
コミット `8969e01` で claude-code ラッパーから機能制限する環境変数を除去する `overrideAttrs` を導入したが、直後の PR #19（`a07c553`）でモジュール構造をリファクタリングした際に、このブロックが新ファイルに移行されず消失していた。

## Test plan
- [x] `nix run .#build` でビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)