### PR TITLE
feat(nvim): live_grep に rg 引数フィルタ機能を追加

### DIFF
--- a/config/nvim/lua/plugins/configs/telescope.lua
+++ b/config/nvim/lua/plugins/configs/telescope.lua
@@ -42,15 +42,24 @@ telescope.setup({
       require("telescope.themes").get_dropdown({}),
     },
     file_browser = {},
+    live_grep_args = {
+      auto_quoting = true,
+      mappings = {
+        i = {
+          ["<C-g>"] = require("telescope-live-grep-args.actions").quote_prompt(),
+        },
+      },
+    },
   },
 })
 telescope.load_extension("fzf")
 telescope.load_extension("ui-select")
 telescope.load_extension("file_browser")
+telescope.load_extension("live_grep_args")
 
 local builtin = require("telescope.builtin")
 vim.keymap.set("n", "<leader>ff", builtin.find_files)
-vim.keymap.set("n", "<leader>fg", builtin.live_grep)
+vim.keymap.set("n", "<leader>fg", telescope.extensions.live_grep_args.live_grep_args)
 vim.keymap.set("n", "<leader>fb", builtin.buffers)
 vim.keymap.set("n", "<leader>fd", builtin.diagnostics)
 vim.keymap.set("n", "<leader>fs", builtin.treesitter)

--- a/config/nvim/lua/plugins/telescope.lua
+++ b/config/nvim/lua/plugins/telescope.lua
@@ -8,6 +8,7 @@ return {
   { "nvim-tree/nvim-web-devicons", lazy = true },
   { "nvim-lua/plenary.nvim", lazy = true },
   { "nvim-telescope/telescope-file-browser.nvim", lazy = true },
+  { "nvim-telescope/telescope-live-grep-args.nvim", lazy = true },
   {
     "nvim-telescope/telescope.nvim",
     cmd = "Telescope",


### PR DESCRIPTION
## Summary
- `telescope-live-grep-args.nvim` を導入し、`<leader>fg` で rg の引数を直接入力可能に
- `"search" -g "*.lua"` のようにファイル名フィルタ、`-t` でファイルタイプ指定が可能
- `<C-g>` で検索語の手動クォート切り替えに対応

## 変更内容
- `config/nvim/lua/plugins/telescope.lua`: プラグインエントリ追加
- `config/nvim/lua/plugins/configs/telescope.lua`: extension 設定・ロード・キーマップ変更

## Test plan
- [ ] `nix run .#switch` で設定を適用
- [ ] `<leader>fg` でプロンプトが表示され、通常の検索が動作する
- [ ] `"function" -g "*.lua"` で `.lua` ファイルのみに絞られる
- [ ] `<C-g>` で検索語が自動クォートされる
- [ ] `<Esc>`, `<C-j>`, `<C-k>` の既存マッピングが維持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)