### PR TITLE
feat(fish): worktree 作成と Claude Code 起動を行う cw コマンドを追加

### DIFF
--- a/config/fish/functions/cw.fish
+++ b/config/fish/functions/cw.fish
@@ -1,0 +1,44 @@
+function cw --description "Create worktree and launch Claude Code"
+    if test (count $argv) -eq 0
+        echo "Usage: cw <task description or branch name>"
+        return 1
+    end
+
+    set -l branch
+
+    # `/` を含む場合はブランチ名として直接使用
+    if string match -q '*/*' "$argv[1]"
+        set branch $argv[1]
+    else
+        # Claude にブランチ名を生成させる
+        set -l task (string join " " $argv)
+        set branch (claude -p "Generate a git branch name for this task. Output only the branch name in format: feat/xxx, fix/xxx, refactor/xxx, chore/xxx, docs/xxx. No explanation. Task: $task")
+        set branch (string trim $branch)
+        if test -z "$branch"
+            echo "Failed to generate branch name"
+            return 1
+        end
+        echo "Branch: $branch"
+        read -P "OK? [Y/n] " confirm
+        if test "$confirm" = n -o "$confirm" = N
+            return 1
+        end
+    end
+
+    # ブランチの存在チェックで gwq add のフラグを決定（ローカル + リモート）
+    if git branch --list "$branch" | string match -qr '\S'; or git branch -r --list "origin/$branch" | string match -qr '\S'
+        gwq add "$branch"; or return 1
+    else
+        gwq add -b "$branch"; or return 1
+    end
+
+    # worktree パスを取得して移動
+    set -l wt_path (git worktree list | grep -F "[$branch]" | awk '{print $1}')
+    if test -z "$wt_path"
+        echo "Failed to find worktree path for $branch"
+        return 1
+    end
+
+    cd $wt_path
+    and claude --allow-dangerously-skip-permissions
+end

--- a/nix/modules/home/programs/fish.nix
+++ b/nix/modules/home/programs/fish.nix
@@ -6,6 +6,7 @@
     "fish/functions/dev.fish".source = ../../../../config/fish/functions/dev.fish;
     "fish/functions/ghq-fzf.fish".source = ../../../../config/fish/functions/ghq-fzf.fish;
     "fish/functions/wt-fzf.fish".source = ../../../../config/fish/functions/wt-fzf.fish;
+    "fish/functions/cw.fish".source = ../../../../config/fish/functions/cw.fish;
   };
 
   programs.fish = {


### PR DESCRIPTION
## Summary
- タスク説明 or ブランチ名を渡すだけで「ブランチ名生成 → worktree 作成 → 移動 → Claude Code 起動」を一発で行う Fish 関数 `cw` を追加
- ブランチ名に `/` を含む場合は直接使用、含まない場合は Claude にブランチ名を生成させて確認プロンプトを表示
- ローカル・リモート両方のブランチ存在チェックに対応し、`gwq add` のフラグを適切に選択

## Test plan
- [x] `nix run .#build` でビルド成功を確認
- [ ] `nix run .#switch` で適用後、新しいシェルで `cw` のヘルプが表示されることを確認
- [ ] `cw feat/test-branch` でブランチ名直接指定の動作確認
- [ ] `cw add auth feature` でブランチ名生成フローの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
