### PR TITLE
fix(nix): nix run .#switch のエラー・警告を全修正

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -11,7 +11,6 @@
   homebrew = {
     casks = [
       "datagrip"
-      "zoom"
     ];
     masApps = {};
   };

--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -9,6 +9,13 @@
   # Nix settings (Determinate Nix manages the daemon)
   nix.enable = false;
 
+  # Determinate Nix の /etc/nix/nix.conf は `!include nix.custom.conf` で
+  # 追加設定を読み込む。cachix substituter を trusted に登録する。
+  environment.etc."nix/nix.custom.conf".text = ''
+    extra-trusted-substituters = https://ryoppippi.cachix.org
+    extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms=
+  '';
+
   # System packages (CLIツールはhome/packages.nixで管理)
   environment.systemPackages = [];
 

--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -3,9 +3,9 @@
   programs.git = {
     enable = true;
     lfs.enable = true;
-    userName = profile.git.userName;
-    userEmail = profile.git.userEmail;
     settings = {
+      user.name = profile.git.userName;
+      user.email = profile.git.userEmail;
       color.ui = "auto";
       commit = {
         gpgsign = profile.git.gpgSign or true;

--- a/nix/modules/home/programs/neovim.nix
+++ b/nix/modules/home/programs/neovim.nix
@@ -12,7 +12,7 @@
       gopls
       lua-language-server
       llvmPackages.clang-tools # clangd
-      dockerfile-language-server-nodejs
+      dockerfile-language-server
       docker-compose-language-service
       vscode-langservers-extracted # html, json, css
       marksman


### PR DESCRIPTION
## Summary

- **git.nix**: 非推奨の `programs.git.userName`/`userEmail` を `settings` ブロック内の `user.name`/`user.email` に移動
- **neovim.nix**: リネーム済みパッケージ `dockerfile-language-server-nodejs` → `dockerfile-language-server` に更新
- **default.nix**: Determinate Nix の `nix.custom.conf` で `ryoppippi.cachix.org` を trusted substituter に登録（毎回の信頼プロンプトを解消）
- **work.nix**: IT部門プリインストール済み Zoom を Homebrew casks リストから削除（`brew bundle` の pkg installer エラーを回避）

## Test plan

- [ ] `nix run .#build` でビルド成功を確認
- [ ] `programs.git.userName/userEmail` のリネーム警告が消えていることを確認
- [ ] `dockerfile-language-server-nodejs` のリネーム警告が消えていることを確認
- [ ] `nix run .#switch` で `brew bundle` が Zoom エラーで失敗しないことを確認
- [ ] 2回目の `nix run .#switch` で cachix 信頼プロンプトが出ないことを確認

> ⚠️ cachix の信頼プロンプトは初回 switch 時にはまだ設定が反映されていないため表示される。2回目以降で解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)