### PR TITLE
fix(nix): substituter をデーモンレベルに統合し冗長な nixConfig を削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,6 @@
 {
   description = "Kurichi's dotfiles managed by nix-darwin and home-manager";
 
-  nixConfig = {
-    extra-substituters = [
-      "https://ryoppippi.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms="
-    ];
-  };
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 

--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -12,6 +12,7 @@
   # Determinate Nix の /etc/nix/nix.conf は `!include nix.custom.conf` で
   # 追加設定を読み込む。cachix substituter を trusted に登録する。
   environment.etc."nix/nix.custom.conf".text = ''
+    extra-substituters = https://ryoppippi.cachix.org
     extra-trusted-substituters = https://ryoppippi.cachix.org
     extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms=
   '';


### PR DESCRIPTION
## Summary

- `nix.custom.conf` に `extra-substituters` を追加し、cachix substituter をデーモンレベルで直接利用するように変更
- `flake.nix` から冗長な `nixConfig` ブロックを削除（trusted-users 未設定のため機能せず、毎回 6 行の警告を出力していた）
- 既存の `/etc/nix/nix.custom.conf`（Determinate Nix installer 由来）は手動でリネーム済み

## Background

PR #26 で追加された `environment.etc."nix/nix.custom.conf"` が cachix substituter 設定を書き込もうとするが、Determinate Nix installer が作成した既存ファイルの内容と不一致のため nix-darwin の安全機構が activation を中断していた。

また `flake.nix` の `nixConfig` はクライアントレベルの設定だが、ユーザーが trusted-users に含まれていないため無視され、代わりに毎回警告が出力されていた。

## Changes

### `nix/modules/darwin/default.nix`
- `extra-substituters` 行を追加（デーモンが cachix を自動利用）
- 既存の `extra-trusted-substituters` + `extra-trusted-public-keys` はそのまま維持

### `flake.nix`
- `nixConfig` ブロック全体を削除（Step 2 の設定で完全にカバー）

## Test plan

- [x] `nix run .#build` でビルド成功を確認
- [ ] `nix run .#switch` で activation 成功を確認
- [ ] `nix show-config` で substituter がデーモンレベルで有効か確認
- [ ] 再度 `nix run .#switch` 実行時に substituter 警告が消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)