### PR TITLE
fix(wt): worktree 配置を .wt/ に変更し cw の gwq 依存を除去

### DIFF
--- a/config/claude/hooks/guard-worktree.sh
+++ b/config/claude/hooks/guard-worktree.sh
@@ -35,7 +35,10 @@ HOOKJSON
 fi
 
 # === main worktree パスへの参照もブロック（git -C <main> 等） ===
-if echo "$COMMAND" | grep -qF "$MAIN_WORKTREE"; then
+# .wt/ がメインリポジトリ内にある場合、linked worktree パスが main パスの
+# プレフィックスを含むため誤検知する。現在の worktree パスを先に除去してからチェック。
+COMMAND_STRIPPED="${COMMAND//"$WORKTREE_ROOT"/__CURRENT_WT__}"
+if echo "$COMMAND_STRIPPED" | grep -qF "$MAIN_WORKTREE"; then
   cat <<HOOKJSON
 {
   "hookSpecificOutput": {

--- a/config/fish/functions/cw.fish
+++ b/config/fish/functions/cw.fish
@@ -25,18 +25,40 @@ function cw --description "Create worktree and launch Claude Code"
         end
     end
 
-    # ブランチの存在チェックで gwq add のフラグを決定（ローカル + リモート）
-    if git branch --list "$branch" | string match -qr '\S'; or git branch -r --list "origin/$branch" | string match -qr '\S'
-        gwq add "$branch"; or return 1
-    else
-        gwq add -b "$branch"; or return 1
+    # スラッグ生成（/ → - に置換してフラットなディレクトリ名にする）
+    set -l slug (string replace -a '/' '-' $branch)
+    set -l repo_root (git rev-parse --show-toplevel)
+    set -l wt_path "$repo_root/.wt/$slug"
+
+    # 既存 worktree が同ブランチに存在する場合は再作成せず移動のみ
+    if git worktree list | string match -q "*[$branch]*"
+        cd $wt_path
+        and claude --allow-dangerously-skip-permissions
+        return
     end
 
-    # worktree パスを取得して移動
-    set -l wt_path (git worktree list | grep -F "[$branch]" | awk '{print $1}')
-    if test -z "$wt_path"
-        echo "Failed to find worktree path for $branch"
-        return 1
+    # ワークツリー作成（ブランチ存在有無で分岐）
+    mkdir -p "$repo_root/.wt"
+    if git branch --list "$branch" | string match -qr '\S'
+        # ローカルブランチが既に存在する
+        git worktree add "$wt_path" "$branch"; or return 1
+    else if git branch -r --list "origin/$branch" | string match -qr '\S'
+        # リモートにのみ存在する → ローカルブランチを追跡付きで作成
+        git worktree add "$wt_path" "$branch"; or return 1
+    else
+        # 新規ブランチ
+        git worktree add -b "$branch" "$wt_path"; or return 1
+    end
+
+    # copyignored: .gitignore で無視されているがトラッキング外のファイルをコピー
+    set -l ignored_files (git ls-files --ignored --exclude-standard --others)
+    for f in $ignored_files
+        set -l src "$repo_root/$f"
+        set -l dst "$wt_path/$f"
+        if test -f "$src"
+            mkdir -p (dirname "$dst")
+            cp "$src" "$dst"
+        end
     end
 
     cd $wt_path

--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -40,7 +40,10 @@
       };
       user.signingkey = profile.git.signingKey or "/Users/${username}/.ssh/github.pub";
       ghq.root = "~/repos";
-      wt.copyignored = true;
+      wt = {
+        basedir = ".wt";
+        copyignored = true;
+      };
     };
     ignores = [
       ".wt/"


### PR DESCRIPTION
## Summary
- `git.nix`: `wt.basedir = ".wt"` を追加し、worktree をリポジトリ内 `.wt/` 配下に配置するよう変更
- `cw.fish`: 削除済みの `gwq` コマンドを `git worktree add` に置換。ブランチ名 `/` → `-` 変換でフラットなディレクトリ名を生成（例: `feat/add-auth` → `.wt/feat-add-auth`）
- `guard-worktree.sh`: `.wt/` がメインリポジトリ内にあることで linked worktree パスが main worktree パスのプレフィックスを含む誤検知を修正

## Test plan
- [ ] `nix run .#build` でビルドエラーがないことを確認
- [ ] `git config wt.basedir` が `.wt` を返すことを確認（rebuild 後）
- [ ] `cw feat/test-something` で `.wt/feat-test-something` にワークツリーが作成されること
- [ ] `guard-worktree.sh`: linked worktree 内からのファイル参照が許可されること
- [ ] `guard-worktree.sh`: main worktree への直接参照が拒否されること
- [ ] `git wt -d feat/test-something` で削除できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)