### PR TITLE
chore(nix): Claude Code 2.1.56 → 2.1.63 へ更新

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772003987,
-        "narHash": "sha256-6EIkULpbsKgCZCf1dRftrIY8+StocP50x2AfvDSe51U=",
+        "lastModified": 1772252606,
+        "narHash": "sha256-SiIhFq4XbD3LmODQ2mTtakRBnjBn/KoSgAOId1cL1Ks=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "b10b550d3d78cb7e0789d4a4b4d599d96016db92",
+        "rev": "b1ebf027412136bbbe4202741c3d48721644bc4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- `claude-code-overlay` flake input を最新 (2026-02-28) に更新
- Claude Code 2.1.56 → 2.1.63 へバージョンアップ
- `nix run .#build` でビルド検証済み

## 変更ファイル

- `flake.lock` のみ

## Test plan

- [x] `nix flake update claude-code-overlay` が正常終了
- [x] `nix run .#build` でビルドが通ること
- [ ] `nix run .#switch` で適用確認（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)