### PR TITLE
fix(nix): personal プロファイルに Zoom を再追加

### DIFF
--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -19,6 +19,7 @@
       "postman-agent"
       "slack"
       "steam"
+      "zoom"
     ];
     masApps = {
       LINE = 539883307;


### PR DESCRIPTION
## Summary

- personal プロファイルの Homebrew casks に `zoom` を追加
- `homebrew.nix` の `cleanup = "zap"` により cask リストから外れていた Zoom を復元

## 変更ファイル

- `nix/hosts/personal.nix`

## Test plan

- [ ] `nix run .#switch` で Zoom がインストールされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)