### PR TITLE
chore(nix): google-cloud-sdk をグローバルパッケージに追加

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -49,6 +49,7 @@
 
     # Infrastructure
     terraform
+    google-cloud-sdk
 
     # Build tools
     ninja


### PR DESCRIPTION
## Summary

- `nix/modules/home/packages.nix` の Infrastructure セクションに `google-cloud-sdk` を追加
- personal・work 両プロファイルで `gcloud` / `gsutil` / `bq` コマンドが利用可能に
- `nix run .#build` でビルド成功を確認済み

## Test plan

- [x] `nix run .#build` でビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)