### PR TITLE
feat(nvim): review.nvim プラグインを追加

### DIFF
--- a/config/nvim/lua/lazy_nvim.lua
+++ b/config/nvim/lua/lazy_nvim.lua
@@ -15,6 +15,9 @@ local opts = {
   defaults = {
     lazy = true,
   },
+  dev = {
+    path = "~/repos/github.com/Kurichi",
+  },
   performance = {
     cache = {
       enabled = true,

--- a/config/nvim/lua/plugins/review.lua
+++ b/config/nvim/lua/plugins/review.lua
@@ -1,0 +1,38 @@
+return {
+  "Kurichi/review.nvim",
+  dev = true,
+  cmd = {
+    "ReviewStart",
+    "ReviewEnd",
+    "ReviewResume",
+    "ReviewList",
+    "ReviewExport",
+    "ReviewMark",
+    "ReviewUnmark",
+    "ReviewStatus",
+  },
+  keys = {
+    { "<leader>Rc", desc = "Add review comment" },
+    { "<leader>Rr", desc = "Resolve comment" },
+    { "<leader>Rw", desc = "Wontfix comment" },
+    { "<leader>Rd", desc = "Delete comment" },
+    { "]r",         desc = "Next open comment" },
+    { "[r",         desc = "Previous open comment" },
+    { "<leader>Rl", desc = "List comments" },
+    { "<leader>Rm", desc = "Mark file reviewed" },
+    { "<leader>Rt", desc = "Toggle resolved" },
+  },
+  opts = {
+    keymaps = {
+      add_comment = "<leader>Rc",
+      resolve = "<leader>Rr",
+      wontfix = "<leader>Rw",
+      delete = "<leader>Rd",
+      next_comment = "]r",
+      prev_comment = "[r",
+      list_comments = "<leader>Rl",
+      mark_file = "<leader>Rm",
+      toggle_resolved = "<leader>Rt",
+    },
+  },
+}


### PR DESCRIPTION
## Summary

- ローカルの `review.nvim` プラグイン（`~/repos/github.com/Kurichi/review.nvim`）を Neovim 設定に追加
- `lazy_nvim.lua` に `dev.path` を設定し、lazy.nvim の dev 機能でローカルプラグインを解決
- `cmd` + `keys` による遅延読み込みで起動時間に影響なし
- `<leader>R` プレフィックスで既存キーマップ（`<leader>r` = LSP rename）との競合を回避

## Test plan

- [ ] Neovim を起動し `:Lazy` でプラグイン一覧に `review.nvim` が表示されることを確認（dev マークつき）
- [ ] `:ReviewStart --base main --head HEAD` でセッションが開始できることを確認
- [ ] `<leader>Rc` でコメント追加フローティングウィンドウが表示されることを確認
- [ ] `<leader>r` で LSP rename が遅延なく即座に発動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)