### PR TITLE
feat(work): Bitwarden 導入 + Git commit signing 有効化

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -10,6 +10,7 @@
 
   homebrew = {
     casks = [
+      "bitwarden"
       "datagrip"
     ];
     masApps = {};

--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -5,8 +5,11 @@
   git = {
     userName = "Yuya Kurihara";
     userEmail = "kurihara_yuya@cyberagent.co.jp";
-    gpgSign = false;
+    signingKey = "/Users/s30264/.ssh/id_ed25519.pub";
+    gpgSign = true;
   };
+
+  sshAuthSock = "/Users/s30264/.bitwarden-ssh-agent.sock";
 
   homebrew = {
     casks = [

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -1,4 +1,5 @@
-_: {
+{ profile, ... }:
+{
   # Environment variables
   home.sessionVariables = {
     # AI Tools
@@ -7,5 +8,7 @@ _: {
     GEMINI_CLI_HOME = "$HOME/.config";  # ~/.config/.gemini/ に設定保存
     # pnpm
     PNPM_HOME = "$HOME/.local/share/pnpm";
-  };
+  } // (if profile ? sshAuthSock then {
+    SSH_AUTH_SOCK = profile.sshAuthSock;
+  } else {});
 }

--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -31,8 +31,9 @@
       rerere.enabled = true;
       gpg = {
         format = "ssh";
-        ssh.program = profile.git.gpgSignProgram or "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
-      };
+      } // (if profile.git ? gpgSignProgram then {
+        ssh.program = profile.git.gpgSignProgram;
+      } else {});
       url = {
         "ssh://git@github.com/" = {
           insteadOf = "https://github.com/";


### PR DESCRIPTION
## Summary

- work プロファイルに Bitwarden Desktop（Homebrew cask）を追加
- Bitwarden SSH agent を利用した Git commit signing を有効化
- `gpg.ssh.program` を条件付きに変更し、personal（1Password）との共存を実現

## Changes

### Phase 1: Bitwarden cask 追加
- `nix/hosts/work.nix`: `homebrew.casks` に `"bitwarden"` を追加

### Phase 2: Git commit signing 有効化
- `nix/hosts/work.nix`: `gpgSign=true`, `signingKey`, `sshAuthSock` を設定
- `nix/modules/home/programs/git.nix`: `gpg.ssh.program` を `gpgSignProgram` 属性の有無で条件分岐
- `nix/modules/home/dotfiles.nix`: `SSH_AUTH_SOCK` を `profile.sshAuthSock` がある場合のみ export

## How it works

| | personal | work |
|---|---|---|
| Password Manager | 1Password | Bitwarden |
| `gpg.ssh.program` | `op-ssh-sign` | 未設定（SSH_AUTH_SOCK 経由） |
| `SSH_AUTH_SOCK` | 未設定 | `~/.bitwarden-ssh-agent.sock` |
| `commit.gpgsign` | `true` | `true` |

## Prerequisites (manual setup before `nix run .#switch`)

1. Bitwarden Desktop の Settings → SSH Agent を有効化
2. 署名用 SSH 秘密鍵を Bitwarden Vault に登録
3. `test -S ~/.bitwarden-ssh-agent.sock` でソケット生成を確認

## Test plan

- [x] `darwin-rebuild build --flake .#personal` ビルド成功
- [x] `darwin-rebuild build --flake .#work` ビルド成功
- [x] personal の gitconfig: `gpg.ssh.program = op-ssh-sign` が維持されている
- [x] work の gitconfig: `gpg.ssh.program` が未設定、`commit.gpgsign = true`
- [x] work の session-vars: `SSH_AUTH_SOCK` が設定されている
- [x] personal の session-vars: `SSH_AUTH_SOCK` が未設定
- [ ] `nix run .#switch` 後、`git commit --allow-empty -m "test"` で署名付きコミットが作成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)