### PR TITLE
fix(nix): pnpx が動作しない PATH 優先順位の問題を修正

### DIFF
--- a/nix/modules/darwin/homebrew.nix
+++ b/nix/modules/darwin/homebrew.nix
@@ -7,6 +7,9 @@
       cleanup = "zap";
     };
     caskArgs.appdir = "/Applications";
+    brews = [
+      "asdf"
+    ];
     casks = [
       "1password"
       "homerow"

--- a/nix/modules/home/programs/fish.nix
+++ b/nix/modules/home/programs/fish.nix
@@ -13,18 +13,20 @@
     enable = true;
     interactiveShellInit = ''
       set -g fish_greeting ""
-      # Add home-manager packages to PATH
-      fish_add_path --prepend ~/.local/state/home-manager/gcroots/current-home/home-path/bin
       # nix-darwin
       fish_add_path --append /run/current-system/sw/bin
       # nix (Determinate)
       fish_add_path --append /nix/var/nix/profiles/default/bin
       # Homebrew
       eval (/opt/homebrew/bin/brew shellenv)
+      # asdf version manager
+      source /opt/homebrew/opt/asdf/libexec/asdf.fish
       # VSCode
       fish_add_path --append "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
       # pnpm
       fish_add_path --append $PNPM_HOME
+      # Add home-manager packages to PATH (after asdf to ensure priority over shims)
+      fish_add_path --path --move --prepend ~/.local/state/home-manager/gcroots/current-home/home-path/bin
 
       # git-wt shell integration (completions + auto-cd wrapper)
       git-wt --init fish | source


### PR DESCRIPTION
## Summary
- asdf を Homebrew `brews` に追加し、`fish.nix` で `asdf.fish` を読み込むよう設定
- asdf shims が home-manager バイナリより優先されて `pnpx` が動作しない問題を修正
- `fish_add_path --path --move --prepend` で home-manager を PATH 最前に移動し、asdf shims より優先されるよう変更

## Background
asdf の `source asdf.fish` は `set -gx PATH $shims $PATH` で shim ディレクトリを PATH の最前に挿入するため、Nix の `pnpx` より asdf の shim（exit code 126 で無言失敗）が先に見つかる状態だった。

## Changes
- `nix/modules/darwin/homebrew.nix`: `brews` リストを新設し `asdf` を追加
- `nix/modules/home/programs/fish.nix`: home-manager PATH 追加を asdf 読み込みの後に移動し、`--path --move --prepend` で確実に先頭配置

## Test plan
- [ ] `nix run .#switch` で適用
- [ ] 新しい fish シェルで `which pnpx` が `~/.local/state/home-manager/.../home-path/bin/pnpx` を返すこと
- [ ] `pnpx --help` が正常に動作すること
- [ ] `echo $PATH | tr ' ' '\n' | head -5` で home-path/bin が asdf/shims より前にあること

🤖 Generated with [Claude Code](https://claude.com/claude-code)