### PR TITLE
feat(nix): Fish をデフォルトシェルに設定

### DIFF
--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -17,6 +17,9 @@
     extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms=
   '';
 
+  # Enable Fish shell system-wide (/etc/shells registration + completions)
+  programs.fish.enable = true;
+
   # System packages (CLIツールはhome/packages.nixで管理)
   environment.systemPackages = [];
 

--- a/nix/modules/darwin/system.nix
+++ b/nix/modules/darwin/system.nix
@@ -1,4 +1,4 @@
-{ username, hostname, ... }:
+{ username, hostname, pkgs, ... }:
 
 {
   # Primary user (required for system.defaults options)
@@ -38,6 +38,7 @@
   users.users.${username} = {
     name = username;
     home = "/Users/${username}";
+    shell = pkgs.fish;
   };
 
   # Enable sudo with Touch ID (new syntax)


### PR DESCRIPTION
## Summary

- `programs.fish.enable = true` で Fish を `/etc/shells` に登録（nix-darwin レベル）
- `users.users.${username}.shell = pkgs.fish` でログインシェルを Fish に変更
- 既存の home-manager Fish 設定との整合性を維持

## Background

Fish shell は home-manager 経由でインストール・設定済みだったが、macOS のログインシェルは `/bin/bash` のままだった。
この変更により `darwin-rebuild switch` 適用後、ログインシェルが正式に Fish になる。

## Test plan

- [x] `nix run .#build` でビルド成功を確認
- [ ] `darwin-rebuild switch` 適用後、`dscl . -read /Users/$USER UserShell` で Fish パスを確認
- [ ] `cat /etc/shells` で Fish が登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)