### PR TITLE
feat(nix): Datadog pup CLI を Homebrew 経由で追加

### DIFF
--- a/nix/modules/darwin/homebrew.nix
+++ b/nix/modules/darwin/homebrew.nix
@@ -7,8 +7,12 @@
       cleanup = "zap";
     };
     caskArgs.appdir = "/Applications";
+    taps = [
+      "datadog-labs/pack"
+    ];
     brews = [
       "asdf"
+      "datadog-labs/pack/pup"
     ];
     casks = [
       "1password"

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -10,7 +10,6 @@
     fzf
     ghq
     jq
-    pup
     just
     tree
     tmux


### PR DESCRIPTION
## Summary
- nixpkgs の HTML パーサー `pup` を削除し、Datadog の [`pup` CLI](https://github.com/datadog-labs/pup) を Homebrew 経由でインストール
- `datadog-labs/pack` tap を `homebrew.taps` に追加
- `datadog-labs/pack/pup` を `homebrew.brews` に追加

## Test plan
- [x] `nix run .#build` でビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)