### PR TITLE
fix(nix): claude-code-overlay の fetch を SSH 経由に変更

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773279016,
-        "narHash": "sha256-XUJKpaYSwrMlsX1lBSHaU5MD1tsPEot4ISfl6xmEkjY=",
+        "lastModified": 1773451814,
+        "narHash": "sha256-ncqkZfGjNMNjnUHyBPqPCuM1IdlfbP+PTDw4eoJwbYM=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "526985f15c6703289de4f3bf1d8f623098245efe",
+        "rev": "0d9fb590af016130d71cf810ade72cdd7ab60f4c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     };
 
     claude-code-overlay = {
-      url = "github:ryoppippi/claude-code-overlay";
+      url = "git+ssh://git@github.com/ryoppippi/claude-code-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Summary
- `claude-code-overlay` の input URL を `github:` → `git+ssh://` に変更
- GitHub API のレート制限 (HTTP 403) を回避するため、SSH プロトコル経由で fetch するように切り替え

## Test plan
- [ ] `nix flake update claude-code-overlay` が SSH 経由で成功すること
- [ ] `nix run .#build` でビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)