### PR TITLE
fix(nix): GitHub API レート制限を access-tokens で回避

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773451814,
-        "narHash": "sha256-ncqkZfGjNMNjnUHyBPqPCuM1IdlfbP+PTDw4eoJwbYM=",
+        "lastModified": 1774525081,
+        "narHash": "sha256-5KFUqokTqcmEUQNhrdxZVPfBFHUrDtAhljixn2fPhWI=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "0d9fb590af016130d71cf810ade72cdd7ab60f4c",
+        "rev": "893ee907cd44982b98d9a6d1d3f884615f88460e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     };
 
     claude-code-overlay = {
-      url = "git+ssh://git@github.com/ryoppippi/claude-code-overlay";
+      url = "github:ryoppippi/claude-code-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/nix/modules/darwin/default.nix
+++ b/nix/modules/darwin/default.nix
@@ -15,6 +15,7 @@
     extra-substituters = https://ryoppippi.cachix.org
     extra-trusted-substituters = https://ryoppippi.cachix.org
     extra-trusted-public-keys = ryoppippi.cachix.org-1:b2LbtWNvJeL/qb1B6TYOMK+apaCps4SCbzlPRfSQIms=
+    !include /etc/nix/access-tokens.conf
   '';
 
   # Enable Fish shell system-wide (/etc/shells registration + completions)


### PR DESCRIPTION
## Summary
- `nix.custom.conf` に `!include /etc/nix/access-tokens.conf` を追加し、`github:` スキームの API リクエストを認証済みにすることでレート制限 (HTTP 403) を回避
- `claude-code-overlay` の URL を `git+ssh://` → `github:` に戻し（sudo darwin-rebuild で root SSH 鍵がなく失敗するため）
- `flake.lock` の claude-code-overlay を最新リビジョン (893ee90) に更新

## 背景
- `github:` スキームは GitHub REST API 経由で tarball を取得するため、未認証だと 60 req/h のレート制限
- `access-tokens` を設定すると 5,000 req/h に緩和される
- `/etc/nix/access-tokens.conf` は手動で配置（Nix store に入れないため）

## Test plan
- [x] `nix flake update claude-code-overlay` が 403 なしで成功
- [x] `nix run .#switch` が正常完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)