### PR TITLE
fix(nix): Claude Code v2.1.87 にピン留めして GCS 404 エラーを回避

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774525081,
-        "narHash": "sha256-5KFUqokTqcmEUQNhrdxZVPfBFHUrDtAhljixn2fPhWI=",
+        "lastModified": 1774942693,
+        "narHash": "sha256-76W0bV+u6wtuB+9+LEC8CYLSmxGBY8pFhXHXW/iBn24=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "893ee907cd44982b98d9a6d1d3f884615f88460e",
+        "rev": "3e1dea4c8ecb882f50e28b130a3ffc7032ac5ba6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -72,11 +72,17 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "backup";
-              home-manager.extraSpecialArgs = { inherit username llmPkgs profile; };
+              home-manager.extraSpecialArgs = {
+                inherit username llmPkgs profile;
+                claudeCodePkg = claude-code-overlay.packages.${system}."2.1.87";
+              };
               home-manager.users.${username} = import ./nix/modules/home;
             }
           ];
-          specialArgs = { inherit inputs username hostname llmPkgs profile; };
+          specialArgs = {
+            inherit inputs username hostname llmPkgs profile;
+            claudeCodePkg = claude-code-overlay.packages.${system}."2.1.87";
+          };
         };
     in
     assert lib.assertMsg

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -1,4 +1,4 @@
-{ pkgs, llmPkgs, profile, ... }:
+{ pkgs, llmPkgs, profile, claudeCodePkg, ... }:
 
 {
   home.packages = with pkgs; [
@@ -28,7 +28,7 @@
     git-wt
 
     # AI tools
-    (pkgs.claude-code.overrideAttrs (old: {
+    (claudeCodePkg.overrideAttrs (old: {
       postFixup = builtins.replaceStrings
         [
           "--set DISABLE_TELEMETRY 1"


### PR DESCRIPTION
## Summary
- `claude-code-overlay` の default パッケージ (v2.1.88) のバイナリが GCS から削除されビルド不能になっていた
- overlay の versioned package `"2.1.87"` を `claudeCodePkg` として `specialArgs` / `extraSpecialArgs` 経由で直接参照するように変更
- `flake.lock` の `claude-code-overlay` リビジョンも最新に更新

## Test plan
- [x] `nix build github:ryoppippi/claude-code-overlay#packages.aarch64-darwin."2.1.87"` で v2.1.87 のビルド成功を確認
- [x] `nix run .#build` でシステム全体のビルド成功を確認
- [x] Codex CLI review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)