### PR TITLE
feat(fish): personal PC で c エイリアスに --allow-dangerously-skip-permissions を付与

### DIFF
--- a/nix/modules/home/programs/fish.nix
+++ b/nix/modules/home/programs/fish.nix
@@ -53,7 +53,9 @@
       # nix
       rebuild = "darwin-rebuild switch --flake ~/repos/github.com/Kurichi/dotfiles#${profile.profileName}";
       # claude
-      c = "claude";
+      c = if profile.profileName == "personal"
+        then "claude --allow-dangerously-skip-permissions"
+        else "claude";
     };
     functions = {
       fish_prompt = ''


### PR DESCRIPTION
## Summary
- personal プロファイルのみ `c` abbreviation を `claude --allow-dangerously-skip-permissions` に変更
- work プロファイルは従来通り `claude` のまま

## Test plan
- [x] `nix run .#build` でビルド成功を確認
- [x] Codex CLI レビュー APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)