### PR TITLE
chore(nix): update flake inputs, add proton-pass, misc config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775261198,
-        "narHash": "sha256-BdXWR+LoP8K0V71oT1pNXdlajowVxaLiXXeDXMdvLoM=",
+        "lastModified": 1775993372,
+        "narHash": "sha256-tjbFyOz7qleQtb4/DJ2+TOPem1aHflA16CJzdq9M+mo=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "e4ec05a124e6a206e405091f245449291c58e8b6",
+        "rev": "80e4d98153594e34118f0d8cdb65c837caf05214",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -74,14 +74,14 @@
               home-manager.backupFileExtension = "backup";
               home-manager.extraSpecialArgs = {
                 inherit username llmPkgs profile;
-                claudeCodePkg = claude-code-overlay.packages.${system}."2.1.87";
+                claudeCodePkg = claude-code-overlay.packages.${system}.default;
               };
               home-manager.users.${username} = import ./nix/modules/home;
             }
           ];
           specialArgs = {
             inherit inputs username hostname llmPkgs profile;
-            claudeCodePkg = claude-code-overlay.packages.${system}."2.1.87";
+            claudeCodePkg = claude-code-overlay.packages.${system}.default;
           };
         };
     in

--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -24,6 +24,7 @@
       "orbstack"
       "postman-agent"
       "proton-mail"
+      "proton-pass"
       "slack"
       "steam"
       "zoom"

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -5,6 +5,7 @@
     # AI Tools
     CODEX_HOME = "$HOME/.config/codex";
     CLAUDE_CONFIG_DIR = "$HOME/.config/claude";
+    CLAUDE_CODE_NO_FLICKER = "1";
     GEMINI_CLI_HOME = "$HOME/.config";  # ~/.config/.gemini/ に設定保存
     # pnpm
     PNPM_HOME = "$HOME/.local/share/pnpm";


### PR DESCRIPTION
## Summary
- claude-code-overlay flake input を更新し、固定バージョンから `default` パッケージに切り替え
- personal プロファイルに `proton-pass` (Homebrew cask) を追加
- `CLAUDE_CODE_NO_FLICKER` 環境変数を追加

## Test plan
- [ ] `nix run .#build` でビルドが通ることを確認
- [ ] `nix run .#switch` で適用後、Proton Pass がインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)