### PR TITLE
chore(nix): add proton-drive to personal casks

### DIFF
--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -25,6 +25,7 @@
       "postman-agent"
       "proton-mail"
       "proton-pass"
+      "proton-drive"
       "slack"
       "steam"
       "zoom"


### PR DESCRIPTION
## Summary
- personal プロファイルの Homebrew casks に `proton-drive` を追加

## Test plan
- [x] `nix run .#build` でビルド成功を確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)