### PR TITLE
refactor(fish): claude の --allow-dangerously-skip-permissions を削除

### DIFF
--- a/config/fish/functions/cw.fish
+++ b/config/fish/functions/cw.fish
@@ -33,7 +33,7 @@ function cw --description "Create worktree and launch Claude Code"
     # 既存 worktree が同ブランチに存在する場合は再作成せず移動のみ
     if git worktree list | string match -q "*[$branch]*"
         cd $wt_path
-        and claude --allow-dangerously-skip-permissions
+        and claude
         return
     end
 
@@ -62,5 +62,5 @@ function cw --description "Create worktree and launch Claude Code"
     end
 
     cd $wt_path
-    and claude --allow-dangerously-skip-permissions
+    and claude
 end

--- a/nix/modules/home/programs/fish.nix
+++ b/nix/modules/home/programs/fish.nix
@@ -53,9 +53,7 @@
       # nix
       rebuild = "darwin-rebuild switch --flake ~/repos/github.com/Kurichi/dotfiles#${profile.profileName}";
       # claude
-      c = if profile.profileName == "personal"
-        then "claude --allow-dangerously-skip-permissions"
-        else "claude";
+      c = "claude";
     };
     functions = {
       fish_prompt = ''


### PR DESCRIPTION
## Summary
- auto mode の登場により permission bypass フラグが不要になったため、fish abbreviation `c` と `cw` 関数の両方から `--allow-dangerously-skip-permissions` を削除
- `c` の personal/work プロファイル分岐も解消し、単純な `claude` 起動へ統一
- 関連: #43 (`feat(fish): personal PC で c エイリアスに --allow-dangerously-skip-permissions を付与`) を実質的に巻き戻し

## Test plan
- [ ] `nix run .#build` がエラーなく通ること
- [ ] `nix run .#switch` 適用後、新シェルで `c<space>` が `claude ` に展開されること（`--allow-dangerously-skip-permissions` が付かない）
- [ ] `cw <task>` 実行時に `claude` が permission bypass フラグなしで起動すること