### PR TITLE
chore(nix): bump claude-code-overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775993372,
-        "narHash": "sha256-tjbFyOz7qleQtb4/DJ2+TOPem1aHflA16CJzdq9M+mo=",
+        "lastModified": 1777072284,
+        "narHash": "sha256-LSPT8NDDgIxagZJiOQyVzHwXO5MEy8Kdze3wXwDbcfY=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "80e4d98153594e34118f0d8cdb65c837caf05214",
+        "rev": "320f208e33fc5375e0789243ff56bb168c5972ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- `claude-code-overlay` の flake input を `80e4d98` → `320f208e33fc5375e0789243ff56bb168c5972ef` へ更新

## Test plan
- [ ] `nix run .#build` が成功すること
- [ ] `nix run .#switch` 適用後、`claude --version` が想定どおり起動すること