### PR TITLE
feat(fish): claude abbreviation に --worktree を既定で付与

### DIFF
--- a/nix/modules/home/programs/fish.nix
+++ b/nix/modules/home/programs/fish.nix
@@ -53,7 +53,7 @@
       # nix
       rebuild = "darwin-rebuild switch --flake ~/repos/github.com/Kurichi/dotfiles#${profile.profileName}";
       # claude
-      c = "claude";
+      c = "claude --worktree";
     };
     functions = {
       fish_prompt = ''


### PR DESCRIPTION
## Summary
- fish abbreviation `c` を `claude` から `claude --worktree` に変更
- 毎回 worktree モードで Claude Code を起動できるようにする

## Test plan
- [x] `nix run .#build` が成功することを確認
- [ ] `nix run .#switch` 適用後、新しい fish セッションで `c<space>` が `claude --worktree ` に展開されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)