### PR TITLE
chore(ci): introduce Renovate-driven nix flake update automation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,36 @@
+name: flake check
+
+on:
+  pull_request:
+    paths:
+      - flake.nix
+      - flake.lock
+      - "nix/**"
+      - renovate.json
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - name: nix flake check
+        run: nix flake check --all-systems --no-build
+
+      - name: Evaluate darwinConfigurations
+        run: |
+          nix eval .#darwinConfigurations.personal.system.outPath --raw
+          nix eval .#darwinConfigurations.work.system.outPath --raw

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommitsDisabled"
+  ],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "updateNotScheduled": false,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies", "nix"],
+  "commitMessagePrefix": "chore(nix):",
+  "commitMessageAction": "bump",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newValue}}",
+  "commitMessageSuffix": "[skip-review]",
+  "nix": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["nix"],
+      "automerge": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  }
+}


### PR DESCRIPTION
## Summary
- `nix flake update` を Renovate Mend App で週次自動化（月曜 9:00 JST、input ごとに個別 PR）。
- 受け入れ側の評価層 CI として `nix flake check --no-build` と `darwinConfigurations.{personal,work}` の eval を `macos-15` runner で実行。

## 設計上の決定
- **コミット規約**: `chore(nix): bump <input> to <newValue> [skip-review]` ── 既存コミット履歴 (5c9b77d 等) と整合。Renovate デフォルトの semantic commit (`chore(deps): ...`) は `:semanticCommitsDisabled` で無効化。
- **PR 粒度**: input ごとに個別 PR（`groupName` 不使用）。`prConcurrentLimit: 5` で 5 input 全てを 1 ラン内に出せる。
- **automerge: false**: nixpkgs-unstable の破壊的変更は eval 通過しても build で死ぬため、手動マージ運用。
- **`flake.nix` `apps.update` は変更せず**: Renovate 障害時の手動 fallback として残す。

## レビュー所見
Codex (gpt-5.4-mini) によるレビュー結果は **P2 が 1 件のみ** (P0/P1 なし):

> `nix flake check --no-build` は評価のみで実ビルドしないため、activation package / パッケージビルド失敗による回帰を CI で検知できない。

これは `.kurichi/plans/nix-flake-update-harmonic-thacker.md` L189 で **意図的に却下されている設計判断**:

> `darwin-rebuild build` を CI に組み込む: nix-darwin インストール込みで毎回 10〜20 分、cost vs benefit が個人 dotfiles で見合わない

実ビルド失敗は手元での `nix run .#build` または `darwin-rebuild switch` で検出する想定。CI は eval 層に絞ってコスト最小化を優先した。

## ユーザー手動アクション (マージ後 1 回のみ)
1. https://github.com/apps/renovate を開く
2. **Configure** → `Kurichi/dotfiles` を Install
3. Mend が initial run を起動し `Dependency Dashboard` Issue を作成

`renovate.json` が既にあるため onboarding PR はスキップされ即稼働。

## Test plan
- [x] `pnpx --package renovate -- renovate-config-validator renovate.json` が `Validation Passed` を返すこと
- [ ] この PR の `flake check` ワークフローが green になること（`paths` に `renovate.json` と `.github/workflows/**` を含めたので bootstrap PR でも発火する）
- [ ] マージ後、Renovate App install 後、初回 PR が `chore(nix): bump <input> to <shortRev> [skip-review]` 形式で出ること
- [ ] PR labels に `dependencies` と `nix` が付与されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)