### PR TITLE
fix(nix): pin llm-agents to dodge fetcherVersion=2 breakage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,19 +6,57 @@
           "llm-agents",
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1771437256,
-        "narHash": "sha256-bLqwib+rtyBRRVBWhMuBXPCL/OThfokA+j6+uH7jDGU=",
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "06ee7190dc2620ea98af9eb225aa9627b68b0e33",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776192490,
+        "narHash": "sha256-5gYQNEs0/vDkHhg63aHS5g0IwG/8HNvU1Vr00cElofk=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "6ef9f144616eedea90b364bb408ef2e1de7b310a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
+        "repo": "bun2nix",
         "type": "github"
       }
     },
@@ -42,6 +80,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -62,25 +121,44 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
         "nixpkgs": [
           "nixpkgs"
         ],
+        "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1772029732,
-        "narHash": "sha256-5kOeqGvyAMiwVhPtN/h09uVMmYLw7faFWjR1CcuVCM0=",
+        "lastModified": 1776977929,
+        "narHash": "sha256-GFSidckz/CKfq8ReHpEpKzqfGWqxPHtw3nMzlGx4REc=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "ee63fee5984b895eaf14a6fb3ca56b773d0dcc3d",
+        "rev": "6ff92d214e3b12013dc9fbc00e32589872a7088c",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "llm-agents.nix",
+        "rev": "6ff92d214e3b12013dc9fbc00e32589872a7088c",
         "type": "github"
       }
     },
@@ -152,11 +230,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # NOTE: 6545e91e (2026-04-23) の "treewide: drop vendored prefetch-npm-deps,
+    # use upstream fetcherVersion=2" 以降、gemini-cli を含む複数パッケージで
+    # npmDepsHash と source の package-lock.json が整合せず ENOTCACHED を起こす。
+    # 暫定として直前の commit 6ff92d21 (gemini-cli 0.39.0 + 旧 fetcher) に pin。
+    # upstream で修正されたらこの pin を外して `github:numtide/llm-agents.nix` に戻す。
     llm-agents = {
-      url = "github:numtide/llm-agents.nix";
+      url = "github:numtide/llm-agents.nix/6ff92d214e3b12013dc9fbc00e32589872a7088c";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary

`darwin-rebuild switch` が `gemini-cli-0.39.1-npm-deps.drv` の hash mismatch で失敗していた問題を修正。

```
specified: sha256-03sY2kafQsWFdvIoPs1Y9POtH+FZkW1T2KEiOCspLYI=
   got:    sha256-y0LafX1+ukW8HRYBqQ3QfZGHo1cVk00bNygdwsBR/7g=
```

## Root cause

upstream `numtide/llm-agents.nix` の commit [`6545e91e`](https://github.com/numtide/llm-agents.nix/commit/6545e91e) (2026-04-23) で全パッケージが vendored `prefetch-npm-deps` から **upstream nixpkgs の `fetcherVersion=2`** に切り替わって以降、`gemini-cli` 0.39.x のビルドが壊れている：

- 単に `npmDepsHash` を「got」値に上書きしても FOD 段階は通るが、その後の `npmConfigHook` が **`ENOTCACHED`**（`strip-ansi` が prefetch 結果に含まれない）で失敗する。
- 原因は v2 fetcher が生成するキャッシュ構造と、ソース側 `package-lock.json` の整合性が崩れていること。upstream HEAD (`f3116258`) でも同じ壊れたハッシュのまま、関連する open issue/PR なし。

## Fix

`flake.nix` で `llm-agents` を `6545e91e` の **直前の commit** `6ff92d21` に pin。
このリビジョンは `gemini-cli` 0.39.0 + 旧 fetcher で正常にビルド可能。

- gemini-cli は 0.39.1 → 0.39.0（patch 1 つ後退、`@github/keytar` 修正は含む）
- 他のパッケージ（codex, copilot-cli 等）も 2026-04-23 時点に固定

## Follow-up

upstream で fetcherVersion=2 への完全移行が完了したら本 pin を外す予定。

## Test plan

- [x] `nix flake lock` で意図通り `llm-agents.original.rev` まで pin される
- [ ] `nix run .#build` が成功する
- [ ] `nix run .#switch` で適用後、`gemini --version` が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)