### PR TITLE
refactor(nix): with pkgs; を排除し pkgs. 明記化に統一

### DIFF
--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -35,9 +35,9 @@
     };
   };
 
-  packages = p: with p; [
-    opensc
-    tailscale
-    valkey
+  packages = p: [
+    p.opensc
+    p.tailscale
+    p.valkey
   ];
 }

--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -19,8 +19,8 @@
     masApps = {};
   };
 
-  packages = p: with p; [
-    awscli2
-    ssm-session-manager-plugin
+  packages = p: [
+    p.awscli2
+    p.ssm-session-manager-plugin
   ];
 }

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -1,31 +1,31 @@
 { pkgs, llmPkgs, profile, claudeCodePkg, ... }:
 
 {
-  home.packages = with pkgs; [
+  home.packages = [
     # CLI tools
-    ripgrep
-    fd
-    bat
-    eza
-    fzf
-    ghq
-    jq
-    just
-    tree
-    tmux
+    pkgs.ripgrep
+    pkgs.fd
+    pkgs.bat
+    pkgs.eza
+    pkgs.fzf
+    pkgs.ghq
+    pkgs.jq
+    pkgs.just
+    pkgs.tree
+    pkgs.tmux
 
     # Development
-    nodejs
-    nodePackages.pnpm
-    bun
-    uv
-    go_1_26
-    rustup
+    pkgs.nodejs
+    pkgs.nodePackages.pnpm
+    pkgs.bun
+    pkgs.uv
+    pkgs.go_1_26
+    pkgs.rustup
 
     # Git tools
-    gh
-    lazygit
-    git-wt
+    pkgs.gh
+    pkgs.lazygit
+    pkgs.git-wt
 
     # AI tools
     (claudeCodePkg.overrideAttrs (old: {
@@ -41,25 +41,27 @@
     llmPkgs.codex
     llmPkgs.gemini-cli
     llmPkgs.copilot-cli
-    moreutils
+    pkgs.moreutils
 
     # Linters
-    actionlint
-    shellcheck
+    pkgs.actionlint
+    pkgs.shellcheck
 
     # Infrastructure
-    terraform
-    (google-cloud-sdk.withExtraComponents [ google-cloud-sdk.components.gke-gcloud-auth-plugin ])
+    pkgs.terraform
+    (pkgs.google-cloud-sdk.withExtraComponents [
+      pkgs.google-cloud-sdk.components.gke-gcloud-auth-plugin
+    ])
 
     # Build tools
-    ninja
+    pkgs.ninja
 
     # PDF tools
-    pkgs."poppler-utils"
+    pkgs.poppler-utils
 
     # Fonts
-    nerd-fonts.hack
-    nerd-fonts.intone-mono
-    noto-fonts-cjk-sans
+    pkgs.nerd-fonts.hack
+    pkgs.nerd-fonts.intone-mono
+    pkgs.noto-fonts-cjk-sans
   ] ++ ((profile.packages or (_: [])) pkgs);
 }

--- a/nix/modules/home/programs/neovim.nix
+++ b/nix/modules/home/programs/neovim.nix
@@ -7,26 +7,26 @@
     viAlias = true;
     vimAlias = true;
 
-    extraPackages = with pkgs; [
+    extraPackages = [
       # LSP Servers
-      gopls
-      lua-language-server
-      llvmPackages.clang-tools # clangd
-      dockerfile-language-server
-      docker-compose-language-service
-      vscode-langservers-extracted # html, json, css
-      marksman
-      python312Packages.python-lsp-server
-      yaml-language-server
-      typescript-language-server
-      typescript
-      terraform-ls
+      pkgs.gopls
+      pkgs.lua-language-server
+      pkgs.llvmPackages.clang-tools # clangd
+      pkgs.dockerfile-language-server
+      pkgs.docker-compose-language-service
+      pkgs.vscode-langservers-extracted # html, json, css
+      pkgs.marksman
+      pkgs.python312Packages.python-lsp-server
+      pkgs.yaml-language-server
+      pkgs.typescript-language-server
+      pkgs.typescript
+      pkgs.terraform-ls
 
       # Formatters / Linters
-      stylua
-      gotools # goimports
-      golangci-lint
-      terraform
+      pkgs.stylua
+      pkgs.gotools # goimports
+      pkgs.golangci-lint
+      pkgs.terraform
     ];
   };
 


### PR DESCRIPTION
## Summary
- 4 ファイル (`packages.nix`, `neovim.nix`, `hosts/personal.nix`, `hosts/work.nix`) から `with pkgs;` / `with p;` shorthand を排除し、`pkgs.X` / `p.X` 明示形に統一
- `pkgs."poppler-utils"` の quote を解除（Nix 識別子規則上 `-` は quote 不要）
- `pkgs.go_1_26` は維持（Codex code-review P2 指摘反映、Go 1.26 → 1.25.5 のダウングレード回避）
- `vscode.nix` は別タスクで Nix 管理外しを検討中のため今回は対象外

バージョン管理は `flake.lock` + 既存 `renovate.json` (nix manager) に一本化されており、本 PR は可読性改善のみで挙動変化なし。`llmPkgs.X` / `claudeCodePkg.overrideAttrs` などの非 nixpkgs 由来パッケージはそのまま維持し、出所がリスト上で読み取れるようにしている。

## Test plan
- [x] `nix flake check --no-build` → all checks passed
- [x] `nix build .#darwinConfigurations.personal.system --no-link` 成立
- [x] `nix build .#darwinConfigurations.work.system --no-link` 成立
- [x] `nix eval` で `home.packages` リスト確認（`go-1.26.0`、両 host とも profile 関数経由のパッケージも含まれる）
- [x] `pkgs.poppler-utils.outPath` 解決確認（`poppler-utils-25.10.0`）
- [x] Codex code-review APPROVED (Standard tier)
- [ ] 実機適用 (`nix run .#switch`) で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)