### PR TITLE
remove: codex を nix から外す

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -38,7 +38,6 @@
         [ "" "" "" ]
         old.postFixup;
     }))
-    llmPkgs.codex
     llmPkgs.gemini-cli
     llmPkgs.copilot-cli
     moreutils


### PR DESCRIPTION
codex-cli が rust で書かれており、ビルドに時間がかかるため。
