### PR TITLE
feat: add proton pass git signing

### DIFF
--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -24,7 +24,6 @@
       "orbstack"
       "postman-agent"
       "proton-mail"
-      "proton-pass"
       "proton-drive"
       "slack"
       "steam"

--- a/nix/modules/darwin/homebrew.nix
+++ b/nix/modules/darwin/homebrew.nix
@@ -17,6 +17,7 @@
     casks = [
       "1password"
       "homerow"
+      "proton-pass"
       "raycast"
       "wezterm@nightly"
     ] ++ (profile.homebrew.casks or []);

--- a/nix/modules/home/launchd.nix
+++ b/nix/modules/home/launchd.nix
@@ -1,4 +1,25 @@
-_: {
+{ pkgs, username, ... }:
+let
+  homeDir = "/Users/${username}";
+  protonPassSigningSock = "${homeDir}/.ssh/proton-pass-agent.sock";
+  protonPassLogPath = "${homeDir}/Library/Logs/proton-pass-ssh-agent.log";
+  startProtonPassSshAgent = pkgs.writeShellScript "start-proton-pass-ssh-agent" ''
+    set -eu
+
+    ${pkgs.coreutils}/bin/mkdir -p "${homeDir}/.ssh" "${homeDir}/Library/Logs"
+
+    if ! ${pkgs.proton-pass-cli}/bin/pass-cli vault list >/dev/null 2>>"${protonPassLogPath}"; then
+      echo "$(${pkgs.coreutils}/bin/date -u +%FT%TZ) proton-pass ssh-agent skipped: pass-cli is not ready" >>"${protonPassLogPath}"
+      exit 0
+    fi
+
+    ${pkgs.coreutils}/bin/rm -f "${protonPassSigningSock}"
+
+    exec ${pkgs.proton-pass-cli}/bin/pass-cli ssh-agent start \
+      --socket-path "${protonPassSigningSock}" \
+      --refresh-interval 3600
+  '';
+in {
   # Startup apps (launchd)
   launchd.enable = true;
   launchd.agents = {
@@ -16,6 +37,20 @@ _: {
         ProgramArguments = [ "/Applications/Homerow.app/Contents/MacOS/Homerow" ];
         RunAtLoad = true;
         KeepAlive = false;
+      };
+    };
+    proton-pass-ssh-agent = {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${startProtonPassSshAgent}" ];
+        RunAtLoad = true;
+        StartInterval = 300;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
+        ProcessType = "Background";
+        StandardOutPath = protonPassLogPath;
+        StandardErrorPath = protonPassLogPath;
       };
     };
   };

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -50,6 +50,7 @@
     # Infrastructure
     terraform
     (google-cloud-sdk.withExtraComponents [ google-cloud-sdk.components.gke-gcloud-auth-plugin ])
+    proton-pass-cli
 
     # Build tools
     ninja

--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -1,5 +1,48 @@
-{ profile, username, ... }:
-{
+{ pkgs, profile, username, ... }:
+let
+  protonPassSigningSock = "/Users/${username}/.ssh/proton-pass-agent.sock";
+  signingKeyPath = profile.git.signingKey or "/Users/${username}/.ssh/github.pub";
+  fallbackSshSignProgram = profile.git.gpgSignProgram or "${pkgs.openssh}/bin/ssh-keygen";
+  protonPassSshSign = pkgs.writeShellScript "git-ssh-sign" ''
+    set -eu
+
+    probe_output="$(${pkgs.coreutils}/bin/mktemp -t proton-pass-signing.XXXXXX)"
+    cleanup() {
+      ${pkgs.coreutils}/bin/rm -f "$probe_output"
+    }
+    trap cleanup EXIT
+
+    if [ -S '${protonPassSigningSock}' ] && [ -r '${signingKeyPath}' ]; then
+      expected_key="$(${pkgs.coreutils}/bin/cut -d' ' -f1,2 '${signingKeyPath}')"
+      if [ -n "$expected_key" ]; then
+        (
+          SSH_AUTH_SOCK='${protonPassSigningSock}' ${pkgs.openssh}/bin/ssh-add -L 2>/dev/null | \
+            ${pkgs.coreutils}/bin/cut -d' ' -f1,2 > "$probe_output"
+        ) &
+        probe_pid=$!
+        (
+          ${pkgs.coreutils}/bin/sleep 2
+          /bin/kill "$probe_pid" 2>/dev/null || true
+        ) &
+        timeout_pid=$!
+
+        if wait "$probe_pid"; then
+          /bin/kill "$timeout_pid" 2>/dev/null || true
+          if ${pkgs.gnugrep}/bin/grep -Fqx "$expected_key" "$probe_output"; then
+            export SSH_AUTH_SOCK='${protonPassSigningSock}'
+            if ${pkgs.openssh}/bin/ssh-keygen "$@"; then
+              exit 0
+            fi
+          fi
+        else
+          /bin/kill "$timeout_pid" 2>/dev/null || true
+        fi
+      fi
+    fi
+
+    exec "${fallbackSshSignProgram}" "$@"
+  '';
+in {
   programs.git = {
     enable = true;
     lfs.enable = true;
@@ -31,15 +74,14 @@
       rerere.enabled = true;
       gpg = {
         format = "ssh";
-      } // (if profile.git ? gpgSignProgram then {
-        ssh.program = profile.git.gpgSignProgram;
-      } else {});
+        ssh.program = "${protonPassSshSign}";
+      };
       url = {
         "ssh://git@github.com/" = {
           insteadOf = "https://github.com/";
         };
       };
-      user.signingkey = profile.git.signingKey or "/Users/${username}/.ssh/github.pub";
+      user.signingkey = signingKeyPath;
       ghq.root = "~/repos";
       wt = {
         basedir = ".wt";


### PR DESCRIPTION
## Summary
- add `proton-pass` as a common Homebrew cask and `proton-pass-cli` as a common Home Manager package
- start a dedicated Proton Pass SSH agent via `launchd` for Git signing
- prefer the Proton Pass signing socket only when the configured signing key is present there, otherwise fall back to the existing signer path

## Verification
- `XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval --raw nixpkgs#proton-pass.pname`
- `XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval --raw nixpkgs#proton-pass-cli.pname`
- `XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval .#darwinConfigurations.personal.config.system.build.toplevel.drvPath`
- `XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval .#darwinConfigurations.work.config.system.build.toplevel.drvPath`
- `git diff --check`

## Follow-up After Merge
- run `pass-cli login` on each target machine
- verify `SSH_AUTH_SOCK=$HOME/.ssh/proton-pass-agent.sock ssh-add -L`
- verify `git commit -S --allow-empty -m test` on both personal and work profiles
- verify normal shell `SSH_AUTH_SOCK` on work still points to Bitwarden outside the signing wrapper