### PR TITLE
fix: use proton pass signing key

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -5,7 +5,8 @@
   git = {
     userName = "Yuya Kurihara";
     userEmail = "kurihara_yuya@cyberagent.co.jp";
-    signingKey = "/Users/s30264/.ssh/id_ed25519.pub";
+    signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGhmZRh1V62B0ijzOjDgjzOOdWfauf3+6FqEd15rIi3p git-signing";
+    signingVaultName = "Personal";
     gpgSign = true;
   };
 

--- a/nix/modules/home/launchd.nix
+++ b/nix/modules/home/launchd.nix
@@ -1,4 +1,4 @@
-{ pkgs, username, ... }:
+{ pkgs, profile, username, ... }:
 let
   homeDir = "/Users/${username}";
   protonPassSigningSock = "${homeDir}/.ssh/proton-pass-agent.sock";
@@ -15,9 +15,17 @@ let
 
     ${pkgs.coreutils}/bin/rm -f "${protonPassSigningSock}"
 
-    exec ${pkgs.proton-pass-cli}/bin/pass-cli ssh-agent start \
-      --socket-path "${protonPassSigningSock}" \
+    agent_args=(
+      ssh-agent
+      start
+      --socket-path "${protonPassSigningSock}"
       --refresh-interval 3600
+    )
+    ${pkgs.lib.optionalString (profile.git ? signingVaultName) ''
+      agent_args+=(--vault-name ${pkgs.lib.escapeShellArg profile.git.signingVaultName})
+    ''}
+
+    exec ${pkgs.proton-pass-cli}/bin/pass-cli "''${agent_args[@]}"
   '';
 in {
   # Startup apps (launchd)

--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -1,7 +1,11 @@
-{ pkgs, profile, username, ... }:
+{ lib, pkgs, profile, username, ... }:
 let
   protonPassSigningSock = "/Users/${username}/.ssh/proton-pass-agent.sock";
-  signingKeyPath = profile.git.signingKey or "/Users/${username}/.ssh/github.pub";
+  hasManagedSigningKey = profile.git ? signingKeyText;
+  signingKeyPath =
+    if hasManagedSigningKey
+    then "/Users/${username}/.ssh/git-signing.pub"
+    else profile.git.signingKey or "/Users/${username}/.ssh/github.pub";
   fallbackSshSignProgram = profile.git.gpgSignProgram or "${pkgs.openssh}/bin/ssh-keygen";
   protonPassSshSign = pkgs.writeShellScript "git-ssh-sign" ''
     set -eu
@@ -43,6 +47,10 @@ let
     exec "${fallbackSshSignProgram}" "$@"
   '';
 in {
+  home.file = lib.optionalAttrs hasManagedSigningKey {
+    ".ssh/git-signing.pub".text = "${profile.git.signingKeyText}\n";
+  };
+
   programs.git = {
     enable = true;
     lfs.enable = true;


### PR DESCRIPTION
## Summary
- point the work profile at the Proton Pass managed git-signing public key
- generate ~/.ssh/git-signing.pub from the profile instead of using the old local id_ed25519.pub
- start the Proton Pass SSH agent with the Personal vault so the signing key is loaded

## Verification
- pass-cli test
- SSH_AUTH_SOCK=/Users/s30264/.ssh/proton-pass-agent.sock ssh-add -L
- XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval .#darwinConfigurations.work.config.system.build.toplevel.drvPath
- XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval .#darwinConfigurations.personal.config.system.build.toplevel.drvPath
- git diff --check
- temporary repo git commit -S smoke test
- latest commit c2fff96 verifies with ED25519 SHA256:3rzyGn+/jbl79biTiuxzEpo8nhHmTmrKdgnI7bW+/PU

## Notes
- GitHub may still show Unverified until this public key is registered as an SSH signing key on the account.