### PR TITLE
fix: set profile git emails

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -4,7 +4,7 @@
 
   git = {
     userName = "Yuya Kurihara";
-    userEmail = "yuya.kurihara@cyberagent.co.jp";
+    userEmail = "kurihara_yuya@cyberagent.co.jp";
     signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGhmZRh1V62B0ijzOjDgjzOOdWfauf3+6FqEd15rIi3p git-signing";
     signingVaultName = "Personal";
     gpgSign = true;

--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -4,7 +4,7 @@
 
   git = {
     userName = "Yuya Kurihara";
-    userEmail = "kurihara_yuya@cyberagent.co.jp";
+    userEmail = "yuya.kurihara@cyberagent.co.jp";
     signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGhmZRh1V62B0ijzOjDgjzOOdWfauf3+6FqEd15rIi3p git-signing";
     signingVaultName = "Personal";
     gpgSign = true;

--- a/nix/modules/home/dotfiles.nix
+++ b/nix/modules/home/dotfiles.nix
@@ -7,6 +7,8 @@
     CLAUDE_CONFIG_DIR = "$HOME/.config/claude";
     CLAUDE_CODE_NO_FLICKER = "1";
     GEMINI_CLI_HOME = "$HOME/.config";  # ~/.config/.gemini/ に設定保存
+    # Git
+    GIT_CONFIG_GLOBAL = "$HOME/.config/git/config";
     # pnpm
     PNPM_HOME = "$HOME/.local/share/pnpm";
   } // (if profile ? sshAuthSock then {


### PR DESCRIPTION
## Summary
- set the work profile Git email to yuya.kurihara@cyberagent.co.jp
- keep the personal profile Git email as me@kurichi.dev
- set GIT_CONFIG_GLOBAL to the Home Manager managed Git config so ~/.gitconfig does not override profile emails

## Verification
- XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval .#darwinConfigurations.work.config.system.build.toplevel.drvPath
- XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval .#darwinConfigurations.personal.config.system.build.toplevel.drvPath
- XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval --raw .#darwinConfigurations.work.config.home-manager.users.s30264.programs.git.settings.user.email
- XDG_CACHE_HOME=/tmp/codex-nix-cache nix eval --raw .#darwinConfigurations.personal.config.home-manager.users.kurichi.programs.git.settings.user.email
- git diff --check
- latest commit verifies locally as yuya.kurihara@cyberagent.co.jp with the Proton Pass signing key