### PR TITLE
fix: direnv の zsh check 停止を回避

### DIFF
--- a/nix/modules/home/programs/direnv.nix
+++ b/nix/modules/home/programs/direnv.nix
@@ -1,6 +1,19 @@
-_: {
+{ pkgs, ... }:
+let
+  direnvPackage =
+    if pkgs.direnv.version == "2.37.1" then
+      pkgs.direnv.overrideAttrs (_old: {
+        doCheck = false;
+      })
+    else
+      throw "Remove direnv doCheck workaround: direnv is ${pkgs.direnv.version}, expected 2.37.1.";
+in
+{
   programs.direnv = {
     enable = true;
+    # nixpkgs 01fbdeef の direnv-2.37.1 は Darwin sandbox 内で test-zsh が
+    # 停止するため、runtime package の build check だけを無効化する。
+    package = direnvPackage;
     nix-direnv.enable = true;
   };
 }


### PR DESCRIPTION
## 概要
- `nixpkgs` 更新後の `direnv-2.37.1` が Darwin の Nix sandbox 内で `test-zsh` に入ると停止するため、Home Manager の `direnv` package に一時回避を追加
- 回避は `direnv 2.37.1` に限定し、将来 version が変わったら評価時に削除判断を促す
- `nix-direnv` の有効化や runtime 設定は変更しない

## 原因
- `direnv` の build check は `bash` / `fish` までは進み、`zsh ./test/direnv-test.zsh` で停止する
- 同じテストは Nix sandbox 外の `/tmp` 再現では通るため、Darwin sandbox 内の `test-zsh` 停止として扱う

## 検証
- `XDG_CACHE_HOME=/tmp/codex-nix-cache nix build .#darwinConfigurations.work.system --no-link --no-write-lock-file`
- `XDG_CACHE_HOME=/tmp/codex-nix-cache nix build .#darwinConfigurations.personal.system --no-link --no-write-lock-file`
- `git diff --check`
- reviewer 再レビュー: actionable finding なし

## 注意
- `switch` は main 限定運用のため、このブランチでは実行していない