### PR TITLE
fix: Raycast の二重起動を止める

### DIFF
--- a/nix/modules/home/launchd.nix
+++ b/nix/modules/home/launchd.nix
@@ -31,14 +31,6 @@ in {
   # Startup apps (launchd)
   launchd.enable = true;
   launchd.agents = {
-    raycast = {
-      enable = true;
-      config = {
-        ProgramArguments = [ "/Applications/Raycast.app/Contents/MacOS/Raycast" ];
-        RunAtLoad = true;
-        KeepAlive = false;
-      };
-    };
     homerow = {
       enable = true;
       config = {


### PR DESCRIPTION
## 概要
- Home Manager の launchd agent から Raycast の RunAtLoad 起動を削除
- Raycast のインストール管理は Homebrew cask のまま維持
- Raycast 自身の login item と repo 管理の launchd 起動が重ならないようにする

## 背景
Raycast が Homebrew cask としてインストールされている一方で、Home Manager の launchd agent でも `/Applications/Raycast.app/Contents/MacOS/Raycast` を RunAtLoad しており、Raycast が二重に立ち上がる状態でした。

## 確認
- `nix eval --json .#darwinConfigurations.work.config.home-manager.users.s30264.launchd.agents`
- `nix eval --json .#darwinConfigurations.work.config.homebrew.casks`
- `nix eval --json .#darwinConfigurations.personal.config.home-manager.users.kurichi.launchd.agents`
- `nix run .#build`
- `git diff --check`