### PR TITLE
fix(nix): pylsp 1.14.0 の checkPhase を overlay でスキップ

### DIFF
--- a/nix/overlays/default.nix
+++ b/nix/overlays/default.nix
@@ -1,1 +1,14 @@
-_final: _prev: { }
+_final: prev: {
+  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+    (_pyFinal: pyPrev:
+      prev.lib.optionalAttrs (pyPrev ? python-lsp-server) {
+        # WORKAROUND: upstream python-lsp/python-lsp-server#605
+        # pytest teardown が closed stream に log を書きにいって落ちるため
+        # checkPhase をスキップする。upstream / nixpkgs 修正後に削除する。
+        python-lsp-server = pyPrev.python-lsp-server.overridePythonAttrs (_: {
+          doCheck = false;
+        });
+      }
+    )
+  ];
+}


### PR DESCRIPTION
## Summary
- `nix run .#switch` が `python-lsp-server-1.14.0` のテスト失敗（upstream [python-lsp/python-lsp-server#605](https://github.com/python-lsp/python-lsp-server/issues/605): pytest teardown で logging on closed stream）で止まる問題の workaround
- `nix/overlays/default.nix` に `pythonPackagesExtensions` 経由で `python-lsp-server` のみ `doCheck = false` を当てる
- upstream / nixpkgs に修正が降りたら overlay 追加分を削除する

## 背景
- `programs.neovim.extraPackages` (`nix/modules/home/programs/neovim.nix:19`) で `python312Packages.python-lsp-server` を引き込んでおり、neovim wrapper の build closure に乗るためエラーが neovim 連鎖失敗を起こしていた
- nixpkgs master でも 1.14.0 + 既存 `disabledTests` の組み合わせで本テスト失敗は拾えていない
- 局所スコープ（`python312Packages` のみ）ではなく追従性を優先して `pythonPackagesExtensions` 経由で当て、`pyPrev ? python-lsp-server` でガード

## Test plan
- [x] `nix eval --raw .#darwinConfigurations.personal.pkgs.python312Packages.python-lsp-server.drvPath` → 新 drv 生成
- [x] `nix derivation show <drv> | jq` → `doCheck: ""`（false 反映）
- [x] `nix run .#build` 完走
- [x] `nix log <drv>` に `pytest` / `test session starts` 出現なし（`pythonImportsCheckPhase` のみ）
- [x] `nix run .#switch` 完走（activation hook 全通）
- [ ] Neovim で Python ファイルを開き `:LspInfo` で `pylsp` attached を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)