### PR TITLE
feat(nix): awscli2 と ssm-session-manager-plugin を全ホスト共通化

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -22,8 +22,5 @@
     masApps = {};
   };
 
-  packages = p: with p; [
-    awscli2
-    ssm-session-manager-plugin
-  ];
+  packages = p: with p; [];
 }

--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -49,6 +49,8 @@
     # Infrastructure
     terraform
     (google-cloud-sdk.withExtraComponents [ google-cloud-sdk.components.gke-gcloud-auth-plugin ])
+    awscli2
+    ssm-session-manager-plugin
     proton-pass-cli
 
     # Build tools


### PR DESCRIPTION
## Summary
- `awscli2` と `ssm-session-manager-plugin` を `nix/hosts/work.nix` から `nix/modules/home/packages.nix` の Infrastructure セクションへ移動
- これにより personal ホストでも `aws` / `session-manager-plugin` が利用可能に
- `terraform` / `google-cloud-sdk` 等の他クラウド系 CLI と同じ粒度で一元管理

## Background
personal 環境で AWS CLI が必要になった。`work.nix` のみに定義されていた状態を解消し、両ホストで共通利用できる構成に整理。`ssm-session-manager-plugin` も AWS 操作の一部として併せて昇格。

## Test plan
- [x] `nix run .#build` が exit 0 で完了（personal プロファイル評価成功）
- [x] `nix run .#switch` で home-manager activation が正常完了
- [x] 適用後に `aws --version` で awscli2 が解決される
- [ ] work プロファイルでも次回適用時に最終構成が変わらないこと（共通側へ移動しただけ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)