### PR TITLE
chore(nix): bump claude-code-overlay digest to 4e1aa4f [skip-review]

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777072284,
-        "narHash": "sha256-LSPT8NDDgIxagZJiOQyVzHwXO5MEy8Kdze3wXwDbcfY=",
+        "lastModified": 1778308634,
+        "narHash": "sha256-PVdOIGVZ+rGXe48IgIy1CA2KC9ukLX1bIjdhexW6kgs=",
         "owner": "ryoppippi",
         "repo": "claude-code-overlay",
-        "rev": "320f208e33fc5375e0789243ff56bb168c5972ef",
+        "rev": "4e1aa4f1557903916b98f4cca32318323c671136",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- `nix flake update claude-code-overlay` の結果を取り込み
- `claude-code-overlay` を `320f208` → `4e1aa4f` (2026-04-24 → 2026-05-09) に更新

## Test plan

- [ ] CI のビルドが通ることを確認
- [ ] `nix run .#build` が成功することを確認（任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)