### PR TITLE
feat(nix): home.packages に xh を追加

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -10,6 +10,7 @@
     fzf
     ghq
     jq
+    xh
     just
     tree
     tmux


### PR DESCRIPTION
## Summary
- Rust 製 HTTP クライアント `xh`（httpie 互換）を `nix/modules/home/packages.nix` の CLI tools セクションに追加。
- nixpkgs から取得され、home-manager 経由で fish completions も自動配置される。

## Test plan
- [x] `nix run .#build` で personal プロファイルのビルド成功を確認（`xh-0.25.3` を cache.nixos.org から取得）
- [ ] マージ後に `nix run .#switch` を適用し、`xh --version` と簡単な HTTP リクエストで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)