### PR TITLE
fix(nix): homebrew の cleanup を無効化して活性化失敗を回避

### DIFF
--- a/nix/modules/darwin/homebrew.nix
+++ b/nix/modules/darwin/homebrew.nix
@@ -4,7 +4,8 @@
     enable = true;
     onActivation = {
       autoUpdate = true;
-      cleanup = "zap";
+      # cleanup は一旦無効化（最近の Homebrew では `brew bundle --cleanup` が --force 必須になり活性化が失敗するため）
+      cleanup = "none";
     };
     caskArgs.appdir = "/Applications";
     taps = [


### PR DESCRIPTION
## 概要

`darwin-rebuild switch`（nix-darwin の Homebrew 活性化）が以下のエラーで失敗する問題を修正する。

```
Error: Invalid usage: `brew bundle install --cleanup` requires `--force`, `--force-cleanup` or `$HOMEBREW_ASK`.
```

## 原因

最近の Homebrew では `brew bundle --cleanup` が非対話実行時に `--force` / `--force-cleanup` / `$HOMEBREW_ASK` のいずれかを要求するようになった。一方、現在 pin している nix-darwin は `cleanup = "zap"` から `brew bundle ... --cleanup --zap`（`--force` なし）を生成するため、活性化が失敗していた。

## 変更内容

`nix/modules/darwin/homebrew.nix` の `onActivation.cleanup` を `"zap"` → `"none"` に変更し、cleanup を一旦無効化する。

- 生成コマンドが `brew bundle --file=... --no-upgrade` のみになり、`--cleanup` フラグが付かないため `--force` 要求自体が発生しない。
- `nix eval .#darwinConfigurations.{personal,work}.config.homebrew.onActivation.brewBundleCmd` で両プロファイルとも `--cleanup --zap` が外れることを確認済み。

## トレードオフ（既知）

cleanup を無効化すると、Brewfile（`profile.homebrew.*`）から削除した formula / cask が自動アンインストールされず、宣言的設定からのドリフトが生じる。これは「いったん」の一時対応であり、後日 `extraFlags = [ "--force" ]` を付与して cleanup を復活させる選択肢も残る。

## 検証

- `nix eval` で `personal` / `work` の生成コマンドに `--cleanup` が含まれないことを確認
- 両プロファイルとも評価エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)