### PR TITLE
feat(nix): work マシンに alt-tab cask を追加

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -14,6 +14,7 @@
 
   homebrew = {
     casks = [
+      "alt-tab"
       "bitwarden"
       "datagrip"
       "rancher"


### PR DESCRIPTION
## Summary
personal マシンのみに登録されていた AltTab(Homebrew cask `alt-tab`)を work マシンでも利用できるよう `nix/hosts/work.nix` の `homebrew.casks` に追加。

nixpkgs 版 `alt-tab-macos` への移行も検討したが、macOS では nix store のパスが更新ごとに変わりアクセシビリティ等の権限を再付与する必要が生じうるため、固定パス(`/Applications`)で権限が安定する Homebrew cask を据え置いた。

## Test plan
- [x] `nix build .#darwinConfigurations.work.system` で evaluation が通ることを確認
- [x] 生成された Brewfile に `cask "alt-tab"` 行が含まれることを確認
- [ ] work マシンで `nix run .#switch` を実行し AltTab が `/Applications` にインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)