### PR TITLE
feat(nix): Notion Calendar を personal と work の両マシンに追加

### DIFF
--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -20,6 +20,7 @@
       "google-chrome"
       "google-drive"
       "notion"
+      "notion-calendar"
       "onedrive"
       "orbstack"
       "postman-agent"

--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -17,6 +17,7 @@
       "alt-tab"
       "bitwarden"
       "datagrip"
+      "notion-calendar"
       "rancher"
       "slack"
     ];


### PR DESCRIPTION
## Summary
- `nix/hosts/personal.nix` と `nix/hosts/work.nix` の `homebrew.casks` に `notion-calendar` を追加
- 両マシンでスケジュール管理に Notion Calendar を使えるようにする

## Test plan
- [ ] `nix run .#build` がエラーなく完了する
- [ ] `nix run .#switch` 後、`/Applications/Notion Calendar.app` がインストールされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)