### PR TITLE
refactor(nix): work マシンの SSH agent を Bitwarden から Proton Pass に変更

### DIFF
--- a/nix/hosts/work.nix
+++ b/nix/hosts/work.nix
@@ -10,12 +10,11 @@
     gpgSign = true;
   };
 
-  sshAuthSock = "/Users/s30264/.bitwarden-ssh-agent.sock";
+  sshAuthSock = "/Users/s30264/.ssh/proton-pass-agent.sock";
 
   homebrew = {
     casks = [
       "alt-tab"
-      "bitwarden"
       "datagrip"
       "notion-calendar"
       "rancher"


### PR DESCRIPTION
## Summary
- `nix/hosts/work.nix` の `sshAuthSock` を Proton Pass agent socket (`~/.ssh/proton-pass-agent.sock`) に切り替え
- `bitwarden` cask を削除（`proton-pass` は `nix/modules/darwin/homebrew.nix` の共通 cask で既に提供済み）
- 既存の `protonPassSshSign` ラッパー（`nix/modules/home/programs/git.nix`）と `proton-pass-ssh-agent` launchd エージェント（`nix/modules/home/launchd.nix`）の仕組みに乗る形で、work も personal と同様に Proton Pass で署名・認証する

## Test plan
- [ ] `nix run .#build` がエラーなく完了する
- [ ] `nix run .#switch` 後、`~/.ssh/proton-pass-agent.sock` 経由で `git commit` の SSH 署名が通る
- [ ] `git push` などの SSH 経由 GitHub アクセスが Proton Pass agent の鍵で認証される
- [ ] `/Applications/Bitwarden.app` がアンインストールされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)