### PR TITLE
feat(nix): displayplacer を共通 brews に追加

### DIFF
--- a/nix/modules/darwin/homebrew.nix
+++ b/nix/modules/darwin/homebrew.nix
@@ -10,10 +10,12 @@
     caskArgs.appdir = "/Applications";
     taps = [
       "datadog-labs/pack"
+      "jakehilborn/jakehilborn"
     ];
     brews = [
       "mise"
       "datadog-labs/pack/pup"
+      "jakehilborn/jakehilborn/displayplacer"
     ];
     casks = [
       "1password"


### PR DESCRIPTION
## Summary
- `jakehilborn/jakehilborn` tap から `displayplacer`（macOS のディスプレイ配置を CLI で管理するツール）を追加
- 既存の `mise` / `datadog-labs/pack/pup` と同様にグローバル `brews` に配置し、personal/work 両プロファイルで利用可能に

## Test plan
- [x] `nix run .#build` でビルド成功を確認（work プロファイル自動判定）
- [x] 生成された Brewfile に `tap "jakehilborn/jakehilborn"` / `brew "jakehilborn/jakehilborn/displayplacer"` が含まれることを確認
- [ ] `nix run .#switch` 適用後、`displayplacer list` で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)