### PR TITLE
feat(claude): Notification フックで macOS 通知センターに表示

### DIFF
--- a/config/claude/hooks/notify.sh
+++ b/config/claude/hooks/notify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code Notification hook
+# permission 要求 or 60 秒アイドルで発火するため、macOS 通知センターに表示する。
+
+INPUT=$(cat) || INPUT='{}'
+MESSAGE=$(printf '%s' "$INPUT" | jq -r '.message // empty' 2>/dev/null || true)
+[ -z "$MESSAGE" ] && MESSAGE="入力を待っています"
+
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
+SUBTITLE=""
+if [ -n "$CWD" ]; then
+  SUBTITLE=$(basename "$CWD")
+fi
+
+escape_for_osascript() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+TITLE_ESC=$(escape_for_osascript "Claude Code")
+MESSAGE_ESC=$(escape_for_osascript "$MESSAGE")
+SUBTITLE_ESC=$(escape_for_osascript "$SUBTITLE")
+
+if [ -n "$SUBTITLE_ESC" ]; then
+  SCRIPT="display notification \"$MESSAGE_ESC\" with title \"$TITLE_ESC\" subtitle \"$SUBTITLE_ESC\" sound name \"Glass\""
+else
+  SCRIPT="display notification \"$MESSAGE_ESC\" with title \"$TITLE_ESC\" sound name \"Glass\""
+fi
+
+osascript -e "$SCRIPT" >/dev/null 2>&1 || true
+
+exit 0

--- a/nix/modules/home/programs/llm-agents.nix
+++ b/nix/modules/home/programs/llm-agents.nix
@@ -21,7 +21,7 @@ let
     reasoningEffort = "medium";
     hooks = {
       PreToolUse = [{ matcher = "Bash"; hooks = [{ type = "command"; command = "$HOME/.config/claude/hooks/guard-worktree.sh"; }]; }];
-      Notification = [{ hooks = [{ type = "command"; command = "afplay /System/Library/Sounds/Glass.aiff"; }]; }];
+      Notification = [{ hooks = [{ type = "command"; command = "$HOME/.config/claude/hooks/notify.sh"; }]; }];
       Stop = [{ hooks = [{ type = "command"; command = "afplay /System/Library/Sounds/Funk.aiff"; }]; }];
     };
     statusLine = { type = "command"; command = "bunx -y ccstatusline@latest"; padding = 0; };


### PR DESCRIPTION
## Summary
- Claude Code が permission を要求した時 / 60 秒アイドル時に発火する `Notification` フックを、`afplay` 音のみから osascript の `display notification` に置き換え、視覚的なバナー通知 + Glass サウンドを同時発火する形に変更
- codex の入力待ち通知に近い体験を実現

## Changes
- 新規: `config/claude/hooks/notify.sh` — stdin の JSON から `message` / `cwd` を抽出し、macOS 通知センターに表示する hook スクリプト（追加依存なし、osascript のみ使用）
- 修正: `nix/modules/home/programs/llm-agents.nix` — `Notification` フックの command を `notify.sh` 呼び出しに変更

## Test plan
- [x] `bash -n notify.sh` で構文検証
- [x] `nix-instantiate --parse llm-agents.nix` で Nix 構文検証
- [x] モック JSON を流し込んで通知表示を実機確認
- [ ] `nix run .#switch` 適用後、Claude Code 起動 → permission 要求で通知バナーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)