### PR TITLE
Configure Claude opusplan defaults

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -35,8 +35,14 @@
           "--set DISABLE_TELEMETRY 1"
           "--set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1"
           "--set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1"
+          "--set DISABLE_INSTALLATION_CHECKS 1"
         ]
-        [ "" "" "" ]
+        [
+          ""
+          ""
+          ""
+          "--set DISABLE_INSTALLATION_CHECKS 1 \\\n  --set ANTHROPIC_DEFAULT_OPUS_MODEL \"claude-fable-5[1m]\""
+        ]
         old.postFixup;
     }))
     llmPkgs.gemini-cli

--- a/nix/modules/home/programs/llm-agents.nix
+++ b/nix/modules/home/programs/llm-agents.nix
@@ -17,7 +17,7 @@ let
       deny = [ "Bash(git reset --hard:*)" ];
       defaultMode = "plan";
     };
-    model = "opus[1m]";
+    model = "opusplan";
     reasoningEffort = "medium";
     hooks = {
       PreToolUse = [{ matcher = "Bash"; hooks = [{ type = "command"; command = "$HOME/.config/claude/hooks/guard-worktree.sh"; }]; }];


### PR DESCRIPTION
## Summary
- Set Claude Code's default model to `opusplan` in the Nix-managed settings merge.
- Add `ANTHROPIC_DEFAULT_OPUS_MODEL="claude-fable-5[1m]"` to the Claude package wrapper so launches through `claude` receive the env var.

## Validation
- `nix flake check --no-build`
- `nix run .#build`
- Confirmed the generated Claude wrapper exports `ANTHROPIC_DEFAULT_OPUS_MODEL='claude-fable-5[1m]'`.
- Confirmed the generated Claude settings JSON contains `"model":"opusplan"`.