### PR TITLE
feat(claude): AskUserQuestion の AFK 自動継続をタイムアウト延長で抑制

### DIFF
--- a/nix/modules/home/programs/llm-agents.nix
+++ b/nix/modules/home/programs/llm-agents.nix
@@ -8,6 +8,10 @@ let
     env = {
       EDITOR = "nvim";
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+      # AskUserQuestion の60秒無応答で自動継続してしまう挙動(AFK auto-continue)の抑制
+      # 0/負数は即時発火する既知のバグがあるため int32 最大値を指定
+      CLAUDE_AFK_TIMEOUT_MS = "2147483647";
+      CLAUDE_AFK_COUNTDOWN_MS = "2147483647";
     };
     permissions = {
       allow = [


### PR DESCRIPTION
## Summary
- `AskUserQuestion` が60秒無応答で回答なしとして自動的に処理を進めてしまう挙動 (AFK auto-continue) を抑制する
- `CLAUDE_AFK_TIMEOUT_MS` / `CLAUDE_AFK_COUNTDOWN_MS` を int32 最大値に設定し、事実上無効化する（0/負数は即時発火する既知のバグがあるため未使用）
- 正式な `settings.json` の opt-out は現時点で存在しないため、未ドキュメントの環境変数で対応（[anthropics/claude-code#73408](https://github.com/anthropics/claude-code/issues/73408)）

Codex review: skipped (trivial change, 設定値の微調整でセキュリティ/CI/Nix実行パスに影響なし)

## Test plan
- [x] `nix run .#build` でビルドが通ることを確認
- [x] 生成された `claude-nix-settings.json` の `env` に両キーが正しく含まれることを確認
- [ ] `darwin-rebuild switch` 適用後、実際に60秒待っても AskUserQuestion が自動継続しないことを確認（要ユーザー環境での動作確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)