### PR TITLE
docs(claude): avoid sandboxed signed commits

### DIFF
--- a/config/claude/CLAUDE.md
+++ b/config/claude/CLAUDE.md
@@ -27,6 +27,7 @@
 
 ### Git コマンド
 - ブランチの作成は `git switch` コマンドを使用してください．
+- この dotfiles では SSH 署名付きコミットと SSH GitHub remote を使用しているため、`git commit` とリモートブランチ初回の `git push` は最初からサンドボックス外実行（許可要求）で行うこと。サンドボックス内で先に失敗させてから署名鍵/socket のブロックを報告する流れにしないこと。
 
 ### GitHub API
 - `gh api` でデータを取得する際は、必ず `--jq` フラグで必要なフィールドのみ抽出すること（トークン節約のため）。
@@ -44,7 +45,7 @@
 - あなたは既に作業用 worktree 内で起動されていることを前提とする。worktree の作成・削除（`git wt <branch>`、`git wt -d <branch>` 等）は自分で行わないこと。
 - main ブランチのワークツリーに直接変更を加えないこと。**起動時のカレントディレクトリから `cd` で離れないこと。**（PreToolUse hook で linked worktree 上での cd/pushd/popd はブロックされる）
 - `/codex:review`（通常の変更）と `/codex:adversarial-review`（セキュリティ・アーキテクチャ変更等）は `disable-model-invocation: true` が設定されており、Claude 自身が自律的に呼び出すことはできない（ユーザーが手動で入力する前提のコマンド）。実装完了後に自動でレビューを走らせたい場合は `/codex:setup --enable-review-gate` で `stopReviewGate`（Stop hook）を有効化しておくこと。これはハーネスレベルで動くため、Claude の判断を介さずターン終了時に自動で diff レビューが走る。
-- `stopReviewGate` が有効な場合、レビューが通過したら、ユーザーに確認せず自動的にコミット・プッシュ・PR 作成まで行ってよい。無効な場合は、コミット前にユーザーへ `/codex:review` の実行を促すこと。
+- `stopReviewGate` が有効な場合、レビューが通過したら、ユーザーに確認せず自動的にコミット・プッシュ・PR 作成まで行ってよい。無効な場合は、コミット前にユーザーへ `/codex:review` の実行を促すこと。ただし `git commit` と初回 `git push` は上記の SSH 署名/認証ルールに従い、最初からサンドボックス外実行として扱うこと。
 
 ## プランモード
 

--- a/config/claude/skills/pr/SKILL.md
+++ b/config/claude/skills/pr/SKILL.md
@@ -43,6 +43,8 @@ tflint --recursive
 
 ### 3. Git 状態確認・コミット
 
+`git status` と `git add` は通常どおり実行してよい。`git commit` は SSH 署名鍵/socket へアクセスするため、最初からサンドボックス外実行（許可要求）で行うこと。サンドボックス内で先に失敗させてから再実行しない。
+
 ```bash
 # 変更状態を確認
 git status
@@ -51,7 +53,7 @@ git status
 # .env, credentials, secrets などは除外
 git add <files>
 
-# Conventional Commit 形式でコミット
+# Conventional Commit 形式でコミット（SSH 署名のため最初からサンドボックス外実行）
 git commit -m "<type>(<scope>): <description>"
 ```
 
@@ -65,8 +67,10 @@ git commit -m "<type>(<scope>): <description>"
 
 ### 4. プッシュ
 
+SSH remote 認証が必要になるため、リモートブランチ初回の `git push -u origin <branch>` は最初からサンドボックス外実行（許可要求）で行うこと。
+
 ```bash
-# リモートブランチの有無を確認し、適切にプッシュ
+# リモートブランチの有無を確認し、適切にプッシュ（初回 push はサンドボックス外実行）
 git push -u origin <branch>
 ```
 


### PR DESCRIPTION
## Summary
- Add a global Claude instruction to run signed `git commit` and initial SSH `git push` outside the sandbox from the first attempt.
- Update the PR workflow and code-review integration so commit/push routes consistently follow that rule.
- Keep the existing Nix/Git signing setup unchanged.

## Test plan
- `git diff --check`
- `nix run .#switch`
- Read back `/Users/s30264/.config/claude/CLAUDE.md` and relevant skill files to confirm the managed config contains the new instructions.
- Implementation review: no actionable findings.

## Notes
- Existing Claude processes may need a new session or restart to reload changed instructions.