### PR TITLE
Ignore .venv when copying git-wt files

### DIFF
--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -94,6 +94,7 @@ in {
       wt = {
         basedir = ".wt";
         copyignored = true;
+        nocopy = [ ".venv/" ];
       };
     };
     ignores = [


### PR DESCRIPTION
## Summary
- Add `.venv/` to `wt.nocopy` in the Home Manager-managed Git config.
- Keep `wt.copyignored = true` while preventing virtualenv directories from being copied into new `git-wt` worktrees.

## Verification
- `git diff --check`
- `nix eval --json .#darwinConfigurations.work.config.home-manager.users.s30264.programs.git.settings.wt.nocopy` -> `[".venv/"]`