### PR TITLE
fix(claude): remove ANTHROPIC_DEFAULT_OPUS_MODEL override

### DIFF
--- a/nix/modules/home/packages.nix
+++ b/nix/modules/home/packages.nix
@@ -35,13 +35,11 @@
           "--set DISABLE_TELEMETRY 1"
           "--set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1"
           "--set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1"
-          "--set DISABLE_INSTALLATION_CHECKS 1"
         ]
         [
           ""
           ""
           ""
-          "--set DISABLE_INSTALLATION_CHECKS 1 \\\n  --set ANTHROPIC_DEFAULT_OPUS_MODEL \"claude-fable-5[1m]\""
         ]
         old.postFixup;
     }))


### PR DESCRIPTION
## Summary
- Claude Code パッケージの `postFixup` に注入していた `--set ANTHROPIC_DEFAULT_OPUS_MODEL "claude-fable-5[1m]"` を削除
- これに伴い無意味になった置換ペア（`--set DISABLE_INSTALLATION_CHECKS 1` を同一文字列に置換していた no-op）も除去

## Test plan
- [x] `nix-instantiate --parse` で構文チェック済み
- [ ] `nix run .#build` でのビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)