### PR TITLE
fix(nix): Proton Pass SSH エージェントの自己破壊を修正し鍵を役割分離

### DIFF
--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -5,9 +5,47 @@
   git = {
     userName = "Kurichi";
     userEmail = "me@kurichi.dev";
-    signingKey = "/Users/kurichi/.ssh/github.pub";
-    gpgSignProgram = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
+    # GitHub に認証用 / 署名用の両方で登録済みの Proton Pass 鍵
+    # ("Proton Pass - Kurichi-MacBook-Pro" / SHA256:FPmyikU3yRQreSoPIl4IJCstOFOcRi+lnWV9nhkNjYE)
+    signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMyXCW68C7NXKIKY/ZPvjcDYSxTLQM4XDQ/BdkULrMEh GitHub - Kurichi-MacBook-Pro";
+    # signingVaultName は意図的に未設定。これは pass-cli ssh-agent start --vault-name に渡され、
+    # 署名鍵だけでなく agent が読み込む鍵全体を絞り込むため、reserpick / lab の鍵が
+    # 別 vault にあると認証が壊れる。3 鍵が同一 vault だと確認できたら設定してよい。
     gpgSign = true;
+  };
+
+  # Proton 専用ソケットが落ちても署名・認証を継続できるよう、
+  # macOS システム ssh-agent にも鍵を投入する（秘密鍵がログインセッション中常駐する）
+  loadKeysIntoSystemAgent = true;
+
+  ssh = {
+    includes = [ "~/.orbstack/ssh/config" ];
+    matchBlocks = {
+      github = {
+        host = "github github.com";
+        hostname = "github.com";
+        user = "git";
+        identityFile = "~/.ssh/git-signing.pub";
+        identityAgent = "~/.ssh/proton-pass-agent.sock";
+        identitiesOnly = true;
+      };
+      reserpick = {
+        hostname = "157.7.113.111";
+        port = 1102;
+        user = "y_kurihara";
+        identityFile = "~/.ssh/reserpick.pub";
+        identityAgent = "~/.ssh/proton-pass-agent.sock";
+        identitiesOnly = true;
+      };
+      lab = {
+        hostname = "131.206.63.6";
+        port = 2019;
+        user = "ykurihara";
+        identityFile = "~/.ssh/lab.pub";
+        identityAgent = "~/.ssh/proton-pass-agent.sock";
+        identitiesOnly = true;
+      };
+    };
   };
 
   homebrew = {

--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -5,8 +5,10 @@
   git = {
     userName = "Kurichi";
     userEmail = "me@kurichi.dev";
-    # GitHub に認証用 / 署名用の両方で登録済みの Proton Pass 鍵
-    # ("Proton Pass - Kurichi-MacBook-Pro" / SHA256:FPmyikU3yRQreSoPIl4IJCstOFOcRi+lnWV9nhkNjYE)
+    # 署名専用の Proton Pass 鍵。認証には使わない
+    # （認証は ssh.identityFiles."github-auth.pub" 側）
+    # TODO: pass-cli login 後に `pass-cli item create ssh-key generate` で生成した
+    #       署名専用鍵に差し替える。現在は暫定で認証鍵と同一。
     signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMyXCW68C7NXKIKY/ZPvjcDYSxTLQM4XDQ/BdkULrMEh GitHub - Kurichi-MacBook-Pro";
     # signingVaultName は意図的に未設定。これは pass-cli ssh-agent start --vault-name に渡され、
     # 署名鍵だけでなく agent が読み込む鍵全体を絞り込むため、reserpick / lab の鍵が
@@ -20,12 +22,19 @@
 
   ssh = {
     includes = [ "~/.orbstack/ssh/config" ];
+
+    identityFiles = {
+      # GitHub 認証専用の Proton Pass 鍵。署名には使わない（署名は
+      # git.signingKeyText -> ~/.ssh/git-signing.pub を使う）
+      "github-auth.pub" = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMyXCW68C7NXKIKY/ZPvjcDYSxTLQM4XDQ/BdkULrMEh GitHub - Kurichi-MacBook-Pro";
+    };
+
     matchBlocks = {
       github = {
         host = "github github.com";
         hostname = "github.com";
         user = "git";
-        identityFile = "~/.ssh/git-signing.pub";
+        identityFile = "~/.ssh/github-auth.pub";
         identityAgent = "~/.ssh/proton-pass-agent.sock";
         identitiesOnly = true;
       };

--- a/nix/hosts/personal.nix
+++ b/nix/hosts/personal.nix
@@ -5,14 +5,12 @@
   git = {
     userName = "Kurichi";
     userEmail = "me@kurichi.dev";
-    # 署名専用の Proton Pass 鍵。認証には使わない
-    # （認証は ssh.identityFiles."github-auth.pub" 側）
-    # TODO: pass-cli login 後に `pass-cli item create ssh-key generate` で生成した
-    #       署名専用鍵に差し替える。現在は暫定で認証鍵と同一。
-    signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMyXCW68C7NXKIKY/ZPvjcDYSxTLQM4XDQ/BdkULrMEh GitHub - Kurichi-MacBook-Pro";
-    # signingVaultName は意図的に未設定。これは pass-cli ssh-agent start --vault-name に渡され、
-    # 署名鍵だけでなく agent が読み込む鍵全体を絞り込むため、reserpick / lab の鍵が
-    # 別 vault にあると認証が壊れる。3 鍵が同一 vault だと確認できたら設定してよい。
+    # 署名専用の Proton Pass 鍵 ("GitHub Signing - Kurichi-MacBook-Pro")。
+    # 認証には使わない（認証は ssh.identityFiles."github-auth.pub" 側）
+    signingKeyText = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPxuyd4whYtHsAZC4ijHnXKNTepukE6sp1mMDECR+kmQ git-signing@Kurichi-MacBook-Pro";
+    # --vault-name は agent が読み込む鍵全体を絞り込む。SSH 鍵はすべて Personal vault に
+    # あることを `pass-cli item list <vault> --filter-type ssh-key` で確認済み。
+    signingVaultName = "Personal";
     gpgSign = true;
   };
 
@@ -35,22 +33,6 @@
         hostname = "github.com";
         user = "git";
         identityFile = "~/.ssh/github-auth.pub";
-        identityAgent = "~/.ssh/proton-pass-agent.sock";
-        identitiesOnly = true;
-      };
-      reserpick = {
-        hostname = "157.7.113.111";
-        port = 1102;
-        user = "y_kurihara";
-        identityFile = "~/.ssh/reserpick.pub";
-        identityAgent = "~/.ssh/proton-pass-agent.sock";
-        identitiesOnly = true;
-      };
-      lab = {
-        hostname = "131.206.63.6";
-        port = 2019;
-        user = "ykurihara";
-        identityFile = "~/.ssh/lab.pub";
         identityAgent = "~/.ssh/proton-pass-agent.sock";
         identitiesOnly = true;
       };

--- a/nix/modules/home/launchd.nix
+++ b/nix/modules/home/launchd.nix
@@ -3,17 +3,111 @@ let
   homeDir = "/Users/${username}";
   protonPassSigningSock = "${homeDir}/.ssh/proton-pass-agent.sock";
   protonPassLogPath = "${homeDir}/Library/Logs/proton-pass-ssh-agent.log";
+  protonPassPidPath = "${homeDir}/.ssh/proton-pass-agent.pid";
+  protonPassStatePath = "${homeDir}/.local/state/proton-pass-ssh-agent.state";
+  # セッション失効時、ユーザーが復旧する手順。通知・ログの両方で同じ文言を使う
+  recoveryHint = "pass-cli login && launchctl kickstart -k gui/$(id -u)/org.nix-community.home.proton-pass-ssh-agent";
+  vaultArg = pkgs.lib.optionalString (profile.git ? signingVaultName)
+    " --vault-name ${pkgs.lib.escapeShellArg profile.git.signingVaultName}";
+  # 秘密鍵を macOS システム ssh-agent にも投入するか（personal のみ）。
+  # Proton 専用ソケットが落ちても署名・認証を継続させるための多重化。
+  loadKeysIntoSystemAgent = profile.loadKeysIntoSystemAgent or false;
   startProtonPassSshAgent = pkgs.writeShellScript "start-proton-pass-ssh-agent" ''
     set -eu
 
-    ${pkgs.coreutils}/bin/mkdir -p "${homeDir}/.ssh" "${homeDir}/Library/Logs"
+    ${pkgs.coreutils}/bin/mkdir -p \
+      "${homeDir}/.ssh" "${homeDir}/Library/Logs" "${homeDir}/.local/state"
 
-    if ! ${pkgs.proton-pass-cli}/bin/pass-cli vault list >/dev/null 2>>"${protonPassLogPath}"; then
-      echo "$(${pkgs.coreutils}/bin/date -u +%FT%TZ) proton-pass ssh-agent skipped: pass-cli is not ready" >>"${protonPassLogPath}"
+    log() {
+      echo "$(${pkgs.coreutils}/bin/date -u +%FT%TZ) $1" >>"${protonPassLogPath}"
+    }
+
+    # 健全 -> 未認証 に遷移した時だけ通知する。5 分ごとの launchd 実行で鳴り続けないように。
+    notify_once() {
+      previous=""
+      if [ -r '${protonPassStatePath}' ]; then
+        previous="$(${pkgs.coreutils}/bin/cat '${protonPassStatePath}' 2>/dev/null || true)"
+      fi
+      echo "$1" >'${protonPassStatePath}' 2>/dev/null || true
+      if [ "$previous" != "$1" ] && [ "$1" = "unauthenticated" ]; then
+        /usr/bin/osascript -e 'display notification "セッションが切れました。pass-cli login を実行してください" with title "Proton Pass SSH agent"' >/dev/null 2>&1 || true
+      fi
+    }
+
+    # ssh-add -l の終了コード: 0 = 鍵あり / 1 = agent は応答するが鍵ゼロ / 2 = agent に接触できない。
+    # 「非ゼロ = ソケットが死んでいる」と誤解すると、セッション失効直後の生きた agent (rc=1) を
+    # stale と誤判定して稼働中のソケットを削除してしまう。
+    probe_agent() {
+      probe_rc_file="$(${pkgs.coreutils}/bin/mktemp -t proton-pass-probe.XXXXXX)"
+      (
+        # サブシェルも set -e を継承するため、`|| inner_rc=$?` で受けないと
+        # ssh-add が非ゼロを返した時点で終了コードを書き出せない
+        inner_rc=0
+        SSH_AUTH_SOCK='${protonPassSigningSock}' \
+          ${pkgs.openssh}/bin/ssh-add -l >/dev/null 2>&1 || inner_rc=$?
+        echo "$inner_rc" >"$probe_rc_file"
+      ) &
+      probe_pid=$!
+      (
+        ${pkgs.coreutils}/bin/sleep 5
+        /bin/kill "$probe_pid" 2>/dev/null || true
+      ) &
+      timeout_pid=$!
+
+      wait "$probe_pid" 2>/dev/null || true
+      /bin/kill "$timeout_pid" 2>/dev/null || true
+
+      # ファイルが空 = タイムアウトで殺された = agent に接触できない (rc=2) 扱い
+      rc=2
+      if [ -s "$probe_rc_file" ]; then
+        rc="$(${pkgs.coreutils}/bin/cat "$probe_rc_file")"
+      fi
+      ${pkgs.coreutils}/bin/rm -f "$probe_rc_file"
+      return "$rc"
+    }
+
+    ${pkgs.lib.optionalString loadKeysIntoSystemAgent ''
+      # Proton 専用ソケットには依存しない。backend から読んで $SSH_AUTH_SOCK の agent へ書くだけ。
+      # exec の後ろでは実行されないため、必ず exec より前で呼ぶこと。
+      load_into_system_agent() {
+        ${pkgs.proton-pass-cli}/bin/pass-cli ssh-agent load${vaultArg} \
+          >>"${protonPassLogPath}" 2>&1 || true
+      }
+    ''}
+
+    stop_old_agent() {
+      [ -r '${protonPassPidPath}' ] || return 0
+      old_pid="$(${pkgs.jq}/bin/jq -r '.pid // empty' '${protonPassPidPath}' 2>/dev/null || true)"
+      [ -n "$old_pid" ] || return 0
+      # PID 再利用に備えて、実際に pass-cli の agent かを確認してから kill する
+      if /bin/ps -p "$old_pid" -o command= 2>/dev/null \
+        | ${pkgs.gnugrep}/bin/grep -q 'pass-cli ssh-agent start'; then
+        /bin/kill "$old_pid" 2>/dev/null || true
+        ${pkgs.coreutils}/bin/sleep 1
+      fi
+    }
+
+    rc=0
+    probe_agent || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+      # 健全。稼働中のソケットには絶対に触らない。
+      notify_once authenticated
+      ${pkgs.lib.optionalString loadKeysIntoSystemAgent "load_into_system_agent"}
       exit 0
     fi
 
+    if ! ${pkgs.proton-pass-cli}/bin/pass-cli vault list >/dev/null 2>>"${protonPassLogPath}"; then
+      log "proton-pass ssh-agent skipped: pass-cli is not ready (recover with: ${recoveryHint})"
+      notify_once unauthenticated
+      # KeepAlive.SuccessfulExit = false のため、非ゼロで抜けると即再起動ループになる
+      exit 0
+    fi
+
+    notify_once authenticated
+    stop_old_agent
     ${pkgs.coreutils}/bin/rm -f "${protonPassSigningSock}"
+    ${pkgs.lib.optionalString loadKeysIntoSystemAgent "load_into_system_agent"}
 
     agent_args=(
       ssh-agent
@@ -45,6 +139,7 @@ in {
         ProgramArguments = [ "${startProtonPassSshAgent}" ];
         RunAtLoad = true;
         StartInterval = 300;
+        ThrottleInterval = 30;
         KeepAlive = {
           SuccessfulExit = false;
         };

--- a/nix/modules/home/programs/default.nix
+++ b/nix/modules/home/programs/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./git.nix
+    ./ssh.nix
     ./fish.nix
     ./fzf.nix
     ./direnv.nix

--- a/nix/modules/home/programs/git.nix
+++ b/nix/modules/home/programs/git.nix
@@ -7,6 +7,13 @@ let
     then "/Users/${username}/.ssh/git-signing.pub"
     else profile.git.signingKey or "/Users/${username}/.ssh/github.pub";
   fallbackSshSignProgram = profile.git.gpgSignProgram or "${pkgs.openssh}/bin/ssh-keygen";
+  allowedSignersPath = "/Users/${username}/.config/git/allowed_signers";
+  # `<type> <base64>` だけに正規化する。コメント欄が付いたままだと突き合わせに失敗しうる
+  signingKeyNormalized =
+    if hasManagedSigningKey
+    then builtins.concatStringsSep " "
+      (lib.take 2 (lib.splitString " " profile.git.signingKeyText))
+    else null;
   protonPassSshSign = pkgs.writeShellScript "git-ssh-sign" ''
     set -eu
 
@@ -44,11 +51,18 @@ let
       fi
     fi
 
+    echo "git-ssh-sign: proton-pass agent unavailable; falling back to ${fallbackSshSignProgram}" >&2
+    echo "git-ssh-sign: recover with: pass-cli login && launchctl kickstart -k gui/\$(id -u)/org.nix-community.home.proton-pass-ssh-agent" >&2
+
     exec "${fallbackSshSignProgram}" "$@"
   '';
 in {
   home.file = lib.optionalAttrs hasManagedSigningKey {
     ".ssh/git-signing.pub".text = "${profile.git.signingKeyText}\n";
+    # `git log --show-signature` / `%G?` がローカルで検証できるようにする。
+    # 未設定だと署名があっても常に E（検証不能）になる。
+    ".config/git/allowed_signers".text =
+      "${profile.git.userEmail} ${signingKeyNormalized}\n";
   };
 
   programs.git = {
@@ -82,7 +96,11 @@ in {
       rerere.enabled = true;
       gpg = {
         format = "ssh";
-        ssh.program = "${protonPassSshSign}";
+        ssh = {
+          program = "${protonPassSshSign}";
+        } // lib.optionalAttrs hasManagedSigningKey {
+          allowedSignersFile = allowedSignersPath;
+        };
       };
       url = {
         "ssh://git@github.com/" = {

--- a/nix/modules/home/programs/ssh.nix
+++ b/nix/modules/home/programs/ssh.nix
@@ -1,0 +1,31 @@
+{ lib, profile, ... }:
+let
+  cfg = profile.ssh or null;
+in
+lib.mkIf (cfg != null) {
+  programs.ssh = {
+    enable = true;
+
+    # 既定値は `AddKeysToAgent no` / `ServerAliveInterval 0` を注入したうえで
+    # ビルドのたびに非推奨警告を出す。必要な値は matchBlocks."*" に明示する。
+    enableDefaultConfig = false;
+
+    # home-manager の生成順は extraOptionOverrides -> Include -> 個別 matchBlocks -> Host *。
+    # OrbStack の Include は「ファイル先頭」でなければ効かないが、この順序により構造的に保証される。
+    includes = cfg.includes or [ ];
+
+    matchBlocks = (cfg.matchBlocks or { }) // {
+      # Host * は最後に出力される。ssh_config は先に読まれた値が勝つので、
+      # 個別ホストの設定がここより優先される。
+      "*" = {
+        addKeysToAgent = "yes";
+        serverAliveInterval = 15;
+        serverAliveCountMax = 30;
+        # UseKeychain に対応するオプションは home-manager に存在しない
+        extraOptions = {
+          UseKeychain = "yes";
+        };
+      };
+    };
+  };
+}

--- a/nix/modules/home/programs/ssh.nix
+++ b/nix/modules/home/programs/ssh.nix
@@ -3,6 +3,13 @@ let
   cfg = profile.ssh or null;
 in
 lib.mkIf (cfg != null) {
+  # 認証用の公開鍵を Nix 管理で配置する。秘密鍵は Proton Pass の agent が保持するため、
+  # ここに置くのは IdentityFile が指す公開鍵のみ。署名鍵 (~/.ssh/git-signing.pub) は
+  # git.nix が別途生成する ―― 認証と署名で鍵を分離するための構成。
+  home.file = lib.mapAttrs'
+    (name: text: lib.nameValuePair ".ssh/${name}" { text = "${text}\n"; })
+    (cfg.identityFiles or { });
+
   programs.ssh = {
     enable = true;
 


### PR DESCRIPTION
## Summary

`git pull` が `Permissions 0644 for '~/.ssh/github.pub' are too open` で失敗する問題の根本修正。パーミッションは症状で、原因は launchd スクリプトが「ソケット削除 → エージェント起動」の順で動いており、Proton Pass セッション失効時に**稼働中のソケットを削除して復旧不能**にしていたこと（2026-08-05T07:51Z のログと orphan プロセスで確定）。

### 変更内容

- **launchd.nix**: `ssh-add -l` の終了コード（0=鍵あり / 1=応答するが鍵ゼロ / 2=接触不能）で健全性を判定し、健全なら何もしない。削除は未接触かつ `vault list` 成功時のみ、削除前に旧プロセスを停止。セッション失効は macOS 通知で可視化（状態遷移時のみ）。`pass-cli ssh-agent load` でシステム ssh-agent にも鍵を投入し多重化（personal のみ）。
- **git.nix**: `gpg.ssh.allowedSignersFile` を追加し署名をローカル検証可能に。フォールバック時に復旧手順を stderr へ出力。
- **ssh.nix（新規）**: `~/.ssh/config` を Nix 管理へ移行。`IdentityAgent` を `Host *` から個別ホストへ移し、暗黙の継承を排除。
- **personal.nix**: 実測で壊れていた 1Password フォールバックを削除。認証鍵（`github-auth.pub`）と署名専用鍵（新規生成 `GitHub Signing - Kurichi-MacBook-Pro`）を分離。未使用の reserpick / lab ホストを削除。

## Test plan

- [x] `nix run .#build` / `nix run .#switch` 成功
- [x] `ssh -T git@github.com` 認証成功（元の症状解消）
- [x] SSH 経由の `git push` 成功
- [x] `ssh -G example.invalid` に IdentityAgent が漏れていない
- [x] 健全なソケットがある状態で launchd ジョブを再実行してもソケットが消えない
- [x] 未認証時はソケットに触れず通知が 1 回だけ出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKuCWM45st1TEq1Dv1NrMi